### PR TITLE
Fix underline safari bug for event speakers MWPW-116886

### DIFF
--- a/blocks/event-speakers/event-speakers.css
+++ b/blocks/event-speakers/event-speakers.css
@@ -41,6 +41,7 @@
     color: var(--text-color);
     font-family: var(--body-font-family);
     display: block;
+    line-height: 1.3;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
- Fix underline safari bug for event speakers

Ticket: [MWPW-116886](https://jira.corp.adobe.com/browse/MWPW-116886)

Before: https://main--bacom--adobecom.hlx.page/docs/library/event-speakers

After: https://event-speakers-underline--bacom--adobecom.hlx.page/docs/library/event-speakers