### PR TITLE
block display for stats links in solutions class

### DIFF
--- a/blocks/stats/stats.css
+++ b/blocks/stats/stats.css
@@ -61,6 +61,10 @@
   margin-top: 0;
 }
 
+.stats .solution a {
+  display: block;
+}
+
 .stats .solution > div > p:first-of-type {
   margin-top: 0;
   margin-bottom: var(--spacing-xs);


### PR DESCRIPTION
Description: 
Quick bug fix I caused in a bulk update. This puts links in the stats > solution section as they were. 

Test URLs:
https://main--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study
https://stats-links-patch--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study