### PR TITLE
Stats logo and icons wrong size

### DIFF
--- a/blocks/stats/stats.css
+++ b/blocks/stats/stats.css
@@ -38,7 +38,7 @@
 }
 
 .stats .stats-intro img {
-  max-height: 85px;
+  max-height: 65px;
   width: auto;
 }
 
@@ -74,6 +74,11 @@
   font-weight: bolder;
 }
 
+.stats .stats-container .stat:nth-child(2) > div > p img {
+  max-height: 70px;
+  width: auto;
+}
+
 /* [template] .featured-story */
 .featured-story .featured-story-wrapper .stats-intro,
 .featured-story .featured-story-wrapper .stats-container {
@@ -105,7 +110,6 @@
   margin: 0;
   padding: 0;
 }
-
 
 /* Tablet */
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
* Adjusted Stats logo size to be smaller
* Adjusted Stats icon in the second column to be smaller.

Resolves: [DOTCOM-72228](https://jira.corp.adobe.com/browse/DOTCOM-72228)

![image](https://user-images.githubusercontent.com/2539954/191341718-86ffb3ac-9ee8-4151-bfe2-44e46ace0e99.png)


**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/sage-case-study?martech=off
- After: https://adjust-stats-logo-icon--bacom--adobecom.hlx.page/customer-success-stories/sage-case-study?martech=off
