### PR TITLE
Remove list style for product lists on customer stories

### DIFF
--- a/blocks/stats/stats.css
+++ b/blocks/stats/stats.css
@@ -70,6 +70,12 @@
   margin-bottom: var(--spacing-xs);
 }
 
+.stats .solution ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .stats .stat:nth-child(n+2){
   padding-top: 0;
 }


### PR DESCRIPTION
Resolves styling for [MWPW-119641](https://jira.corp.adobe.com/browse/MWPW-119641)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/jp/customer-success-stories/abematv-case-study?martech=off
- After: https://bradjohn-stats-list-style--bacom--adobecom.hlx.page/jp/customer-success-stories/abematv-case-study?martech=off
