### PR TITLE
MWPW-120801 - Fix US font

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,7 +25,7 @@ const CONFIG = {
     edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0'
   },
   locales: {
-    '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+    '': { ietf: 'en-US', tk: 'aaz7dvd.css' },
     de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
     kr: { ietf: 'ko-KR', tk: 'zfo3ouc' },
     jp: { ietf: 'ja-JP', tk: 'dvg6awq' },

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,8 +25,8 @@ const CONFIG = {
     edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0'
   },
   locales: {
-    '': { ietf: 'en-US', tk: 'aaz7dvd.css' },
-    de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+    '': { ietf: 'en-US', tk: 'tpc1ntp.css' },
+    de: { ietf: 'de-DE', tk: 'tpc1ntp.css' },
     kr: { ietf: 'ko-KR', tk: 'zfo3ouc' },
     jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   },


### PR DESCRIPTION
* Fix US font

Resolves: [MWPW-120801](https://jira.corp.adobe.com/browse/MWPW-120801)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/methomas/fix-us-font?martech=off
- After: https://methomas-fix-us-font--bacom--adobecom.hlx.page/drafts/methomas/fix-us-font?martech=off

Verification:

- Inspect text in Safari, open the details sidebar, click on the Font tab, verify the name
- To view in Chrome or Firefox, use browserstack so it won't pick up local fonts.

<img width="1920" alt="Screen Shot 2022-11-14 at 3 49 46 PM (2)" src="https://user-images.githubusercontent.com/19690988/202001911-76379272-dab0-45f8-9954-7c85c0b53983.png">