### PR TITLE
MWPW-120502 - PDF Viewer Config

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,9 +25,7 @@ const CONFIG = {
     pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
-  prod: {
-    edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0'
-  },
+  prod: { edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0' },
   locales: {
     '': { ietf: 'en-US', tk: 'hah7vzn.css' },
     de: { ietf: 'de-DE', tk: 'hah7vzn.css' },

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,6 +16,10 @@ const LIBS = '/libs';
 const STYLES = '/styles/styles.css';
 const CONFIG = {
   imsClientId: 'bacom',
+  local: {
+    pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
+    pdfViewerReportSuite: 'adbadobedxqa',
+  },
   stage: {
     edgeConfigId: '7d1ba912-10b6-4384-a8ff-4bfb1178e869',
     pdfViewerClientId: '3b685312b5784de6943647df19f1f492',

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,10 +16,10 @@ const LIBS = '/libs';
 const STYLES = '/styles/styles.css';
 const CONFIG = {
   imsClientId: 'bacom',
-  pdfViewerClientIdStage: '3b685312b5784de6943647df19f1f492',
-  pdfViewerReportSuiteQA: 'adbadobedxqa',
   stage: {
-    edgeConfigId: '7d1ba912-10b6-4384-a8ff-4bfb1178e869'
+    edgeConfigId: '7d1ba912-10b6-4384-a8ff-4bfb1178e869',
+    pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
+    pdfViewerReportSuite: 'adbadobedxqa',
   },
   prod: {
     edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0'


### PR DESCRIPTION
* Move PDF Viewer client ids into env-specific config

Resolves: [MWPW-120502](https://jira.corp.adobe.com/browse/MWPW-120502)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/methomas/pdf-viewsdk?martech=off
- After: https://methomas-pdf-stage-config--bacom--adobecom.hlx.page/drafts/methomas/pdf-viewsdk?martech=off&milolibs=methomas-move-pdf-config

Note: With the feature branch url, the PDF will show an error "Preview not available: This application domain is not authorized..." because the Viewer's client id is specifically for "main--bacom--adobecom.hlx.page". We'll verify once it's merged into main. Any other errors should be flagged though.