### PR TITLE
MWPW-121612 comparison table header fixes

### DIFF
--- a/blocks/comparison/comparison.css
+++ b/blocks/comparison/comparison.css
@@ -73,8 +73,6 @@
 .comparison tbody tr.cta-row th,
 .comparison tbody tr.cta-row td {
   border: none;
-  background: transparent;
-  color: inherit;
 }
 
 .comparison tbody tr:not(.cta-row):hover th,
@@ -107,8 +105,14 @@
   position: initial;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 1200px) {
   .comparison tr th {
+    background: transparent;
+    color: inherit;
+  }
+
+  .comparison tbody tr.cta-row th,
+  .comparison tbody tr.cta-row td {
     background: transparent;
     color: inherit;
   }


### PR DESCRIPTION
* Remove background transparency for tablet and mobile to prevent text overlap.

Resolves: [MWPW-121612](https://jira.corp.adobe.com/browse/MWPW-121612)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/denli/comparison-table?martech=off
- After: https://bmarshal-comparison-fixes--bacom--adobecom.hlx.page/drafts/denli/comparison-table?martech=off
