### PR TITLE
MWPW-118568 PDF viewSDK Live/Prod Credentials

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,7 +25,15 @@ const CONFIG = {
     pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
-  prod: { edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0' },
+  live: {
+    pdfViewerClientId: '23bd4fff42fc4b4da38b3d89492a0abc',
+    pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  prod: {
+    edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0',
+    pdfViewerClientId: '4520c0edfbf147158758d71d18765fec',
+    pdfViewerReportSuite: 'adbadobenonacdcprod,adbadobedxprod,adbadobeprototype',
+  },
   locales: {
     '': { ietf: 'en-US', tk: 'hah7vzn.css' },
     de: { ietf: 'de-DE', tk: 'hah7vzn.css' },


### PR DESCRIPTION
* Add live (.hlx.live) and prod (business.adobe.com) credentials for the PDF viewSDK

Resolves: [MWPW-118568](https://jira.corp.adobe.com/browse/MWPW-118568)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/methomas/pdf-cred-prod?martech=off
- After: https://methomas-pdf-prod-creds--bacom--adobecom.hlx.page/drafts/methomas/pdf-cred-prod?martech=off

Note: The pdf viewer will show an error on the test page because the creds work for the main branch url only