### PR TITLE
MWPW-122331 JP font loaded from Milo

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-@import url('variables.css');
-
 .white-columns .columns > .row {
   padding: 80px 0;
 }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -1,3 +1,0 @@
-:root:lang(ja-JP) {
-  --body-font-family: adobe-clean-han-japanese, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
-}


### PR DESCRIPTION
* Japan font is now enabled by Milo https://github.com/adobecom/milo/pull/370

Resolves: [MWPW-123237](https://jira.corp.adobe.com/browse/MWPW-123237)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/jp/customer-success-stories/pga-tour-case-study?martech=off
- After: https://bmarshal-jp-font--bacom--adobecom.hlx.page/jp/customer-success-stories/pga-tour-case-study?martech=off
