### PR TITLE
increase-code-coverage 

### DIFF
--- a/blocks/comparison/comparison.js
+++ b/blocks/comparison/comparison.js
@@ -21,7 +21,7 @@ const init = async (el) => {
     const cells = Array.from(row.querySelectorAll(':scope > div'));
     const headerCell = cells.shift();
 
-    if (idx === rows.length - 1 && headerCell && headerCell.textContent === '') {
+    if (idx === rows.length - 1 && headerCell?.textContent === '') {
       bodyRow.classList.add('cta-row');
     }
     bodyRow.append(createTag('th', { class: '', scope: 'row' }, headerCell), ...cells.map((cell) => createTag('td', null, cell)));

--- a/blocks/comparison/comparison.js
+++ b/blocks/comparison/comparison.js
@@ -21,7 +21,7 @@ const init = async (el) => {
     const cells = Array.from(row.querySelectorAll(':scope > div'));
     const headerCell = cells.shift();
 
-    if (idx === rows.length - 1 && headerCell.textContent === '') {
+    if (idx === rows.length - 1 && headerCell && headerCell.textContent === '') {
       bodyRow.classList.add('cta-row');
     }
     bodyRow.append(createTag('th', { class: '', scope: 'row' }, headerCell), ...cells.map((cell) => createTag('td', null, cell)));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -116,12 +116,13 @@ const CONFIG = {
     kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
     // Langstore Support.
     langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
-   },
+  },
   // geoRouting: 'on',
   productionDomain: 'business.adobe.com',
 };
 
 // Default to loading the first image as eager.
+/* c8 ignore next 6 */
 (async function loadLCPImage() {
   const lcpImg = document.querySelector('img');
   if (lcpImg) {
@@ -136,7 +137,7 @@ const CONFIG = {
  */
 
 const miloLibs = setLibs(LIBS);
-
+/* c8 ignore next 10] */
 (function loadStyles() {
   const paths = [`${miloLibs}/styles/styles.css`];
   if (STYLES) { paths.push(STYLES); }
@@ -147,7 +148,7 @@ const miloLibs = setLibs(LIBS);
     document.head.appendChild(link);
   });
 }());
-
+/* c8 ignore next 6 */
 (async function loadPage() {
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -122,7 +122,6 @@ const CONFIG = {
 };
 
 // Default to loading the first image as eager.
-/* c8 ignore next 6 */
 (async function loadLCPImage() {
   const lcpImg = document.querySelector('img');
   if (lcpImg) {
@@ -137,7 +136,7 @@ const CONFIG = {
  */
 
 const miloLibs = setLibs(LIBS);
-/* c8 ignore next 10] */
+
 (function loadStyles() {
   const paths = [`${miloLibs}/styles/styles.css`];
   if (STYLES) { paths.push(STYLES); }
@@ -148,7 +147,7 @@ const miloLibs = setLibs(LIBS);
     document.head.appendChild(link);
   });
 }());
-/* c8 ignore next 6 */
+
 (async function loadPage() {
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -7,6 +7,7 @@ export default {
       '**/node_modules/**',
       '**/test/**',
       '**/deps/**',
+      '**/scripts/**',
     ],
   },
   plugins: [importMapsPlugin({})],


### PR DESCRIPTION
* Fixing broken test for comparison

Scripts.js is the only file without 100% coverage. All three functions within the file are:
- crucial to basic page rendering
- called as IIFEs

It would not make sense to export these functions just to test them, and their functionality is core to our site working properly, so one assumes it would be noticed if they were broken. 