### PR TITLE
Init Lana for Bacom

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -150,8 +150,9 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
-  const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
+  const { loadArea, loadDelayed, loadLana, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });
+  loadLana({ clientId: 'bacom' });
   await loadArea();
   loadDelayed();
 }());


### PR DESCRIPTION
* Note that the lana file is not loaded until `window.lana.log` has been called, so there should be no changes to performance.

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/?martech=off
- After: https://c3-initlana--bacom--adobecom.hlx.page/?martech=off
