### PR TITLE
MWPW-120796: Link Localization support for VN_EN and VN_VI

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -114,6 +114,8 @@ const CONFIG = {
     tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
     jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
     kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
+    vn_en: { ietf: 'en', tk: 'pps7abe.css' },
+    vn_vi: { ietf: 'vi-VN', tk: 'jii8bki.css' },
     // Langstore Support.
     langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
   },


### PR DESCRIPTION
Adding the Vietnamese locales to bacom locale list

Resolves: MWPW-120796

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/vn_en/customer-success-stories/umobile-case-study
- After: https://link-transform--bacom--adobecom.hlx.page/vn_en/customer-success-stories/umobile-case-study