### PR TITLE
[MWPW-126441] Unblock style-linting by lowercasing all t-shirt sizes in classnames

### DIFF
--- a/blocks/event-speakers/event-speakers.js
+++ b/blocks/event-speakers/event-speakers.js
@@ -15,7 +15,7 @@ const init = (el) => {
     const readMoreText = readMore?.innerText || READ_MORE;
 
     name?.classList.add('name');
-    name?.querySelector('h1, h2, h3, h4, h5, h6')?.classList.add('body-S');
+    name?.querySelector('h1, h2, h3, h4, h5, h6')?.classList.add('body-s');
     desc?.classList.add('desc');
     readMore?.remove();
 
@@ -33,7 +33,7 @@ const init = (el) => {
 
     const section = document.createElement('section');
 
-    section.classList.add('text', 'body-XS');
+    section.classList.add('text', 'body-xs');
     name.parentNode.insertBefore(section, name);
     section.append(name, desc);
   });

--- a/blocks/stats/stats.js
+++ b/blocks/stats/stats.js
@@ -21,7 +21,7 @@ async function decorateRow(row, module) {
   const headers = row.querySelectorAll('h1, h2, h3, h4, h5, h6');
   if (!headers) return;
   headers.forEach((header) => {
-    const sizes = ['XL', 'L', 'M', 'S', 'XS', 'XS'];
+    const sizes = ['xl', 'l', 'm', 's', 'xs', 'xs'];
     const expr = header.localName;
     const size = parseInt(expr[1], 10);
     header.classList.add(`heading-${sizes[size - 1]}`);

--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -130,8 +130,8 @@ const init = async (el) => {
 
   el.append(nav);
   el.classList.add(`${isAccordion ? 'tree-view-accordion' : 'tree-view-simple'}`);
-  topList.classList.add('top-list', 'body-S');
-  title?.classList.add('title', 'heading-XS');
+  topList.classList.add('top-list', 'body-s');
+  title?.classList.add('title', 'heading-xs');
 
   if (currentLinks.length === 1) { currentLinks[0].classList.add('current-page'); }
 

--- a/test/blocks/stats/stats.test.js
+++ b/test/blocks/stats/stats.test.js
@@ -16,12 +16,12 @@ describe('Stats', () => {
   it('Decorates headers', async () => {
     document.body.innerHTML = '<div class="stats"><div></div><div><h1>Heading 1</h1><h2>Heading 2</h2><h3Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6></div></div>';
     const headingClasses = {
-      h1: 'XL',
-      h2: 'L',
-      h3: 'M',
-      h4: 'S',
-      h5: 'XS',
-      h6: 'XS',
+      h1: 'xl',
+      h2: 'l',
+      h3: 'm',
+      h4: 's',
+      h5: 'xs',
+      h6: 'xs',
     };
     await init(document.querySelector('.stats'));
     [...document.querySelectorAll('h1, h2, h3, h4, h5, h6')].forEach((heading) => {


### PR DESCRIPTION
* NOTE: This PR relates directly to [#503 in the milo repo](https://github.com/adobecom/milo/pull/503) and SHOULD NOT be merged until the PR in milo is merged and then consumed here.
* Updates all CSS rules to use lowercase t-shirt sizes
* Updates all JS files that set classnames to use lowercase t-shirt sizes
* Should allow us to get a clearer picture of style-linting errors moving forward

Resolves: [MWPW-126441](https://jira.corp.adobe.com/browse/MWPW-126441)

**Test URLs:**
(Note that these should both look the same, but the After view uses lowercase t-shirt size classnames)
- Before: https://main--bacom--adobecom.hlx.page/docs/library/blocks/stats?martech=off
- After: https://ebartholomew-kebab-case-tshirts--bacom--adobecom.hlx.page/docs/library/blocks/stats?martech=off
