### PR TITLE
MWPW-128620 loading block styles (stage)

### DIFF
--- a/.github/workflows/run-nala.yaml
+++ b/.github/workflows/run-nala.yaml
@@ -1,0 +1,21 @@
+name: Nala Tests
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  action:
+    name: Running E2E & IT
+    if: contains(github.event.pull_request.labels.*.name, 'run-nala')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Run Nala
+        uses: adobecom/nala@main
+        env:
+          labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          repoName: ${{ github.repository }}

--- a/blocks/chat-cta/chat-cta.css
+++ b/blocks/chat-cta/chat-cta.css
@@ -10,12 +10,6 @@
   background-color: var(--link-color-dark);
 }
 
-[dir=rtl] .cta-chat-sticky {
-  left: 0;
-  right: unset;
-  flex-direction: row-reverse;
-}
-
 .chat-cta .fragment {
   display: flex;
   justify-content: center;
@@ -86,7 +80,7 @@
     align-items: center;
     justify-content: center;
     position: fixed;
-    width: fit-content;
+    width: 120px;
     height: 56px;
     right: 0;
     bottom: 100px;

--- a/blocks/chat-cta/chat-cta.css
+++ b/blocks/chat-cta/chat-cta.css
@@ -10,6 +10,12 @@
   background-color: var(--link-color-dark);
 }
 
+[dir=rtl] .cta-chat-sticky {
+  left: 0;
+  right: unset;
+  flex-direction: row-reverse;
+}
+
 .chat-cta .fragment {
   display: flex;
   justify-content: center;
@@ -80,7 +86,7 @@
     align-items: center;
     justify-content: center;
     position: fixed;
-    width: 120px;
+    width: fit-content;
     height: 56px;
     right: 0;
     bottom: 100px;

--- a/blocks/chat-cta/chat-cta.js
+++ b/blocks/chat-cta/chat-cta.js
@@ -1,27 +1,5 @@
-export default async function init(el) {
-  const block = el;
-  const contentUrl = el.dataset?.content;
-
-  if (contentUrl) {
-    const resp = await fetch(contentUrl);
-    if (!resp.ok) return;
-    const text = await resp.text();
-    if (text) {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(text, 'text/html');
-      const ctaBody = doc.querySelector('.chat-cta > div');
-      if (!ctaBody) return;
-      block.append(ctaBody);
-      const link = ctaBody.querySelector('a');
-      const { pathname, hash } = new URL(link.href, window.location.origin);
-      link.dataset.modalPath = pathname;
-      link.dataset.modalHash = hash;
-      link.href = hash;
-      link.className = 'modal link-block';
-    }
-  }
-
-  const cta = block.children[0].children[0];
+const init = async (el) => {
+  const cta = el.children[0].children[0];
   cta.classList.add('cta-chat-sticky');
 
   const a = cta.querySelector('a');
@@ -34,4 +12,6 @@ export default async function init(el) {
   window.addEventListener('milo:modal:closed', () => {
     cta.classList.remove('cta-hidden');
   });
-}
+};
+
+export default init;

--- a/blocks/chat-cta/chat-cta.js
+++ b/blocks/chat-cta/chat-cta.js
@@ -1,5 +1,27 @@
-const init = async (el) => {
-  const cta = el.children[0].children[0];
+export default async function init(el) {
+  const block = el;
+  const contentUrl = el.dataset?.content;
+
+  if (contentUrl) {
+    const resp = await fetch(contentUrl);
+    if (!resp.ok) return;
+    const text = await resp.text();
+    if (text) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/html');
+      const ctaBody = doc.querySelector('.chat-cta > div');
+      if (!ctaBody) return;
+      block.append(ctaBody);
+      const link = ctaBody.querySelector('a');
+      const { pathname, hash } = new URL(link.href, window.location.origin);
+      link.dataset.modalPath = pathname;
+      link.dataset.modalHash = hash;
+      link.href = hash;
+      link.className = 'modal link-block';
+    }
+  }
+
+  const cta = block.children[0].children[0];
   cta.classList.add('cta-chat-sticky');
 
   const a = cta.querySelector('a');
@@ -12,6 +34,4 @@ const init = async (el) => {
   window.addEventListener('milo:modal:closed', () => {
     cta.classList.remove('cta-hidden');
   });
-};
-
-export default init;
+}

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,7 +1,7 @@
 version: 1
 
 indices:
-  customer-success-stories-us:
+  customer-success-stories-us: &default
     include:
       - '/customer-success-stories/**'
     exclude:
@@ -41,3122 +41,408 @@ indices:
         value: |
           attribute(el, 'href')
   customer-success-stories-ae_ar:
+    <<: *default
     include:
       - '/ae_ar/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ae_ar/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ae_en:
+    <<: *default
     include:
       - '/ae_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ae_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-africa:
+    <<: *default
     include:
       - '/africa/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /africa/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ar:
+    <<: *default
     include:
       - '/ar/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ar/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-at:
+    <<: *default
     include:
       - '/at/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /at/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-au:
+    <<: *default
     include:
       - '/au/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /au/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-be_en:
+    <<: *default
     include:
       - '/be_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /be_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-be_fr:
+    <<: *default
     include:
       - '/be_fr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /be_fr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-be_nl:
+    <<: *default
     include:
       - '/be_nl/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /be_nl/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-bg:
+    <<: *default
     include:
       - '/bg/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /bg/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-br:
+    <<: *default
     include:
       - '/br/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /br/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ca_fr:
+    <<: *default
     include:
       - '/ca_fr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ca_fr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ca:
+    <<: *default
     include:
       - '/ca/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ca/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ch_de:
+    <<: *default
     include:
       - '/ch_de/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ch_de/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ch_fr:
+    <<: *default
     include:
       - '/ch_fr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ch_fr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ch_it:
+    <<: *default
     include:
       - '/ch_it/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ch_it/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cis_en:
+    <<: *default
     include:
       - '/cis_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cis_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cis_ru:
+    <<: *default
     include:
       - '/cis_ru/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cis_ru/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cl:
+    <<: *default
     include:
       - '/cl/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cl/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cn:
+    <<: *default
     include:
       - '/cn/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cn/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-co:
+    <<: *default
     include:
       - '/co/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /co/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cy_en:
+    <<: *default
     include:
       - '/cy_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cy_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-cz:
+    <<: *default
     include:
       - '/cz/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /cz/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-de:
+    <<: *default
     include:
       - '/de/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /de/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-dk:
+    <<: *default
     include:
       - '/dk/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /dk/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ee:
+    <<: *default
     include:
       - '/ee/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ee/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-es:
+    <<: *default
     include:
       - '/es/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /es/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-fi:
+    <<: *default
     include:
       - '/fi/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /fi/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-fr:
+    <<: *default
     include:
       - '/fr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /fr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-gr_en:
+    <<: *default
     include:
       - '/gr_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /gr_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-hk_en:
+    <<: *default
     include:
       - '/hk_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /hk_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-hk_zh:
+    <<: *default
     include:
       - '/hk_zh/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /hk_zh/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-hu:
+    <<: *default
     include:
       - '/hu/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /hu/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-id_en:
+    <<: *default
     include:
       - '/id_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /id_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-id_id:
+    <<: *default
     include:
       - '/id_id/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /id_id/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ie:
+    <<: *default
     include:
       - '/ie/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ie/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-il_en:
+    <<: *default
     include:
       - '/il_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /il_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-il_he:
+    <<: *default
     include:
       - '/il_he/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /il_he/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-in_hi:
+    <<: *default
     include:
       - '/in_hi/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /in_hi/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-in:
+    <<: *default
     include:
       - '/in/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /in/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-it:
+    <<: *default
     include:
       - '/it/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /it/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-jp:
+    <<: *default
     include:
       - '/jp/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /jp/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-kr:
+    <<: *default
     include:
       - '/kr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /kr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-la:
+    <<: *default
     include:
       - '/la/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /la/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-lt:
+    <<: *default
     include:
       - '/lt/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /lt/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-lu_de:
+    <<: *default
     include:
       - '/lu_de/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /lu_de/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-lu_en:
+    <<: *default
     include:
       - '/lu_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /lu_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-lu_fr:
+    <<: *default
     include:
       - '/lu_fr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /lu_fr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-lv:
+    <<: *default
     include:
       - '/lv/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /lv/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-mena_ar:
+    <<: *default
     include:
       - '/mena_ar/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /mena_ar/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-mena_en:
+    <<: *default
     include:
       - '/mena_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /mena_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-mt:
+    <<: *default
     include:
       - '/mt/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /mt/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-mx:
+    <<: *default
     include:
       - '/mx/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /mx/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-my_en:
+    <<: *default
     include:
       - '/my_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /my_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-my_ms:
+    <<: *default
     include:
       - '/my_ms/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /my_ms/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-nl:
+    <<: *default
     include:
       - '/nl/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /nl/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-no:
+    <<: *default
     include:
       - '/no/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /no/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-nz:
+    <<: *default
     include:
       - '/nz/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /nz/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-pe:
+    <<: *default
     include:
       - '/pe/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /pe/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ph_en:
+    <<: *default
     include:
       - '/ph_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ph_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ph_fil:
+    <<: *default
     include:
       - '/ph_fil/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ph_fil/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-pl:
+    <<: *default
     include:
       - '/pl/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /pl/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-pt:
+    <<: *default
     include:
       - '/pt/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /pt/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ro:
+    <<: *default
     include:
       - '/ro/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ro/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ru:
+    <<: *default
     include:
       - '/ru/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ru/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-sa_ar:
+    <<: *default
     include:
       - '/sa_ar/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /sa_ar/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-sa_en:
+    <<: *default
     include:
       - '/sa_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /sa_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-se:
+    <<: *default
     include:
       - '/se/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /se/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-sea:
+    <<: *default
     include:
       - '/sea/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /sea/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-sg:
+    <<: *default
     include:
       - '/sg/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /sg/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-si:
+    <<: *default
     include:
       - '/si/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /si/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-sk:
+    <<: *default
     include:
       - '/sk/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /sk/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-th_en:
+    <<: *default
     include:
       - '/th_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /th_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-th_th:
+    <<: *default
     include:
       - '/th_th/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /th_th/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-tr:
+    <<: *default
     include:
       - '/tr/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /tr/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-tw:
+    <<: *default
     include:
       - '/tw/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /tw/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-ua:
+    <<: *default
     include:
       - '/ua/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /ua/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-uk:
+    <<: *default
     include:
       - '/uk/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /uk/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-vn_en:
+    <<: *default
     include:
       - '/vn_en/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /vn_en/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
   customer-success-stories-vn_vi:
+    <<: *default
     include:
       - '/vn_vi/customer-success-stories/**'
-    exclude:
-      - '**/fragments/**'
     target: /vn_vi/customer-success-stories/query-index.xlsx
-    properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      date:
-        select: head > meta[name="publishdate"]
-        value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      topics:
-        select: head > meta[name="keywords"]
-        value: |
-          attribute(el, 'content')
-      caas-tags:
-        select: main > div > div.card-metadata > div
-        value: |
-          match(el, '[Tt]ags\n(.*)')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
-      breadcrumbsHome:
-        select: .breadcrumbs ul li:first-child a
-        value: |
-          attribute(el, 'href')
+  customer-success-stories-videos:
+    <<: *default
+    include:
+      - '**/fragments/customer-success-stories/featured-videos/**'
+    exclude:
+    target: /fragments/customer-success-stories/featured-videos/query-index.xlsx

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -67,3 +67,7 @@ indices:
         select: none
         value: |
           parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs > ul > li:first-child > a
+        value: |
+          attribute(el, 'href')

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -36,6 +36,907 @@ indices:
         select: none
         value: |
           parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ae_ar:
+    include:
+      - '/ae_ar/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ae_ar/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ae_en:
+    include:
+      - '/ae_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ae_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-africa:
+    include:
+      - '/africa/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /africa/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ar:
+    include:
+      - '/ar/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ar/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-at:
+    include:
+      - '/at/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /at/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-au:
+    include:
+      - '/au/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /au/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-be_en:
+    include:
+      - '/be_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /be_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-be_fr:
+    include:
+      - '/be_fr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /be_fr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-be_nl:
+    include:
+      - '/be_nl/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /be_nl/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-bg:
+    include:
+      - '/bg/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /bg/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-br:
+    include:
+      - '/br/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /br/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ca_fr:
+    include:
+      - '/ca_fr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ca_fr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ca:
+    include:
+      - '/ca/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ca/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ch_de:
+    include:
+      - '/ch_de/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ch_de/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ch_fr:
+    include:
+      - '/ch_fr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ch_fr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ch_it:
+    include:
+      - '/ch_it/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ch_it/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cis_en:
+    include:
+      - '/cis_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cis_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cis_ru:
+    include:
+      - '/cis_ru/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cis_ru/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cl:
+    include:
+      - '/cl/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cl/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cn:
+    include:
+      - '/cn/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cn/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-co:
+    include:
+      - '/co/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /co/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cy_en:
+    include:
+      - '/cy_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cy_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-cz:
+    include:
+      - '/cz/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /cz/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
   customer-success-stories-de:
     include:
       - '/de/customer-success-stories/**'
@@ -63,11 +964,2199 @@ indices:
         select: head > meta[name="keywords"]
         value: |
           attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
       lastModified:
         select: none
         value: |
           parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
       breadcrumbsHome:
-        select: .breadcrumbs > ul > li:first-child > a
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-dk:
+    include:
+      - '/dk/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /dk/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ee:
+    include:
+      - '/ee/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ee/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-es:
+    include:
+      - '/es/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /es/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-fi:
+    include:
+      - '/fi/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /fi/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-fr:
+    include:
+      - '/fr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /fr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-gr_en:
+    include:
+      - '/gr_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /gr_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-hk_en:
+    include:
+      - '/hk_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /hk_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-hk_zh:
+    include:
+      - '/hk_zh/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /hk_zh/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-hu:
+    include:
+      - '/hu/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /hu/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-id_en:
+    include:
+      - '/id_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /id_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-id_id:
+    include:
+      - '/id_id/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /id_id/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ie:
+    include:
+      - '/ie/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ie/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-il_en:
+    include:
+      - '/il_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /il_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-il_he:
+    include:
+      - '/il_he/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /il_he/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-in_hi:
+    include:
+      - '/in_hi/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /in_hi/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-in:
+    include:
+      - '/in/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /in/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-it:
+    include:
+      - '/it/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /it/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-jp:
+    include:
+      - '/jp/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /jp/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-kr:
+    include:
+      - '/kr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /kr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-la:
+    include:
+      - '/la/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /la/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-lt:
+    include:
+      - '/lt/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /lt/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-lu_de:
+    include:
+      - '/lu_de/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /lu_de/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-lu_en:
+    include:
+      - '/lu_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /lu_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-lu_fr:
+    include:
+      - '/lu_fr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /lu_fr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-lv:
+    include:
+      - '/lv/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /lv/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-mena_ar:
+    include:
+      - '/mena_ar/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /mena_ar/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-mena_en:
+    include:
+      - '/mena_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /mena_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-mt:
+    include:
+      - '/mt/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /mt/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-mx:
+    include:
+      - '/mx/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /mx/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-my_en:
+    include:
+      - '/my_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /my_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-my_ms:
+    include:
+      - '/my_ms/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /my_ms/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-nl:
+    include:
+      - '/nl/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /nl/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-no:
+    include:
+      - '/no/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /no/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-nz:
+    include:
+      - '/nz/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /nz/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-pe:
+    include:
+      - '/pe/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /pe/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ph_en:
+    include:
+      - '/ph_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ph_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ph_fil:
+    include:
+      - '/ph_fil/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ph_fil/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-pl:
+    include:
+      - '/pl/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /pl/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-pt:
+    include:
+      - '/pt/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /pt/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ro:
+    include:
+      - '/ro/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ro/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ru:
+    include:
+      - '/ru/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ru/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-sa_ar:
+    include:
+      - '/sa_ar/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /sa_ar/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-sa_en:
+    include:
+      - '/sa_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /sa_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-se:
+    include:
+      - '/se/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /se/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-sea:
+    include:
+      - '/sea/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /sea/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-sg:
+    include:
+      - '/sg/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /sg/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-si:
+    include:
+      - '/si/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /si/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-sk:
+    include:
+      - '/sk/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /sk/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-th_en:
+    include:
+      - '/th_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /th_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-th_th:
+    include:
+      - '/th_th/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /th_th/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-tr:
+    include:
+      - '/tr/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /tr/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-tw:
+    include:
+      - '/tw/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /tw/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-ua:
+    include:
+      - '/ua/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /ua/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-uk:
+    include:
+      - '/uk/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /uk/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-vn_en:
+    include:
+      - '/vn_en/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /vn_en/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
+        value: |
+          attribute(el, 'href')
+  customer-success-stories-vn_vi:
+    include:
+      - '/vn_vi/customer-success-stories/**'
+    exclude:
+      - '**/fragments/**'
+    target: /vn_vi/customer-success-stories/query-index.xlsx
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publishdate"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      topics:
+        select: head > meta[name="keywords"]
+        value: |
+          attribute(el, 'content')
+      caas-tags:
+        select: main > div > div.card-metadata > div
+        value: |
+          match(el, '[Tt]ags\n(.*)')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      breadcrumbsHome:
+        select: .breadcrumbs ul li:first-child a
         value: |
           attribute(el, 'href')

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,7 +7,7 @@ indices:
     exclude:
       - '**/fragments/**'
     target: /customer-success-stories/query-index.xlsx
-    properties:
+    properties: &defaultProps
       title:
         select: head > meta[property="og:title"]
         value: |
@@ -441,8 +441,8 @@ indices:
       - '/vn_vi/customer-success-stories/**'
     target: /vn_vi/customer-success-stories/query-index.xlsx
   customer-success-stories-videos:
-    <<: *default
     include:
       - '**/fragments/customer-success-stories/featured-videos/**'
-    exclude:
     target: /fragments/customer-success-stories/featured-videos/query-index.xlsx
+    properties:
+      <<: *defaultProps

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -160,14 +160,7 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
-  const { loadArea, loadDelayed, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
-  const metaCta = document.querySelector('meta[name="chat-cta"]');
-  const isMetaCtaDisabled = metaCta.content === 'off';
-  if (metaCta && !isMetaCtaDisabled && !document.querySelector('.chat-cta')) {
-    const chatDiv = createTag('div', { class: 'chat-cta meta-cta', 'data-content': metaCta.content });
-    const lastSection = document.body.querySelector('main > div:last-of-type');
-    if (lastSection) lastSection.insertAdjacentElement('beforeend', chatDiv);
-  }
+  const { loadArea, loadDelayed, loadLana, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom' });
   await loadArea();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -160,7 +160,14 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
-  const { loadArea, loadDelayed, loadLana, setConfig } = await import(`${miloLibs}/utils/utils.js`);
+  const { loadArea, loadDelayed, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const metaCta = document.querySelector('meta[name="chat-cta"]');
+  const isMetaCtaDisabled = metaCta.content === 'off';
+  if (metaCta && !isMetaCtaDisabled && !document.querySelector('.chat-cta')) {
+    const chatDiv = createTag('div', { class: 'chat-cta meta-cta', 'data-content': metaCta.content });
+    const lastSection = document.body.querySelector('main > div:last-of-type');
+    if (lastSection) lastSection.insertAdjacentElement('beforeend', chatDiv);
+  }
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom' });
   await loadArea();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -160,7 +160,16 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
-  const { loadArea, loadDelayed, loadLana, setConfig } = await import(`${miloLibs}/utils/utils.js`);
+  const { loadArea, loadDelayed, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const metaCta = document.querySelector('meta[name="chat-cta"]');
+  if (metaCta && !document.querySelector('.chat-cta')) {
+    const isMetaCtaDisabled = metaCta?.content === 'off';
+    if (!isMetaCtaDisabled) {
+      const chatDiv = createTag('div', { class: 'chat-cta meta-cta', 'data-content': metaCta.content });
+      const lastSection = document.body.querySelector('main > div:last-of-type');
+      if (lastSection) lastSection.insertAdjacentElement('beforeend', chatDiv);
+    }
+  }
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom' });
   await loadArea();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,6 +14,7 @@ import { setLibs } from './utils.js';
 
 const LIBS = '/libs';
 const STYLES = '/styles/styles.css';
+const BLOCK_STYLES = ['faas'];
 const CONFIG = {
   imsClientId: 'bacom',
   local: {
@@ -159,6 +160,17 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
+const loadBlockStyles = (selector = 'body > main') => {
+  BLOCK_STYLES.forEach((style) => {
+    if (document.querySelector(`${selector} div.${style}`)) {
+      const link = document.createElement('link');
+      link.setAttribute('rel', 'stylesheet');
+      link.setAttribute('href', `/styles/${style}.css`);
+      document.head.appendChild(link);
+    }
+  });
+};
+
 (async function loadPage() {
   const { loadArea, loadDelayed, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
   const metaCta = document.querySelector('meta[name="chat-cta"]');
@@ -173,5 +185,6 @@ const miloLibs = setLibs(LIBS);
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom' });
   await loadArea();
+  loadBlockStyles();
   loadDelayed();
 }());

--- a/test/blocks/chat-cta/chat-cta.test.js
+++ b/test/blocks/chat-cta/chat-cta.test.js
@@ -2,11 +2,11 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../blocks/chat-cta/chat-cta.js');
 
-describe('Chat CTA', () => {
+describe('Chat CTA Initialization', () => {
   before(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
     const cta = document.querySelector('.chat-cta');
     sinon.spy(window, 'addEventListener');
     await init(cta);

--- a/test/blocks/chat-cta/chat-cta.test.js
+++ b/test/blocks/chat-cta/chat-cta.test.js
@@ -2,11 +2,11 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../blocks/chat-cta/chat-cta.js');
 
-describe('Chat CTA Initialization', () => {
+describe('Chat CTA', () => {
   before(async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
     const cta = document.querySelector('.chat-cta');
     sinon.spy(window, 'addEventListener');
     await init(cta);

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,28 +3,6 @@
   "host": "business.adobe.com",
   "plugins": [
     {
-      "id": "localize",
-      "title": "Localize",
-      "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=bacom--adobecom",
-      "passReferrer": true,
-      "includePaths": [ "**.xlsx**" ]
-    },
-    {
-      "title": "Send to CaaS",
-      "id": "sendtocaas",
-      "environments": ["dev","preview", "live", "prod"],
-      "event": "send-to-caas",
-      "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
-    },
-    {
-      "title": "Check Schema",
-      "id": "checkschema",
-      "environments": ["prod"],
-      "event": "check-schema",
-      "excludePaths": ["/tools**", "*.json"]
-    },
-    {
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
@@ -35,10 +13,53 @@
       "includePaths": [ "**.docx**" ]
     },
     {
+      "id": "tools",
+      "title": "Tools",
+      "isContainer": true
+    },
+    {
+      "containerId": "tools",
+      "id": "localize",
+      "title": "Localize",
+      "environments": [ "edit" ],
+      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=bacom--adobecom",
+      "passReferrer": true,
+      "includePaths": [ "**.xlsx**" ]
+    },
+    {
+      "containerId": "tools",
+      "title": "Send to CaaS",
+      "id": "sendtocaas",
+      "environments": ["dev","preview", "live", "prod"],
+      "event": "send-to-caas",
+      "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
+    },
+    {
+      "containerId": "tools",
+      "title": "Check Schema",
+      "id": "checkschema",
+      "environments": ["prod"],
+      "event": "check-schema",
+      "excludePaths": ["/tools**", "*.json"]
+    },
+    {
+      "containerId": "tools",
       "title": "Preflight",
       "id": "preflight",
       "environments": ["dev", "preview", "live"],
       "event": "preflight"
+    },
+    {
+      "containerId": "tools",
+      "id": "locales",
+      "title": "Locales",
+      "environments": [ "edit", "dev", "preview", "live" ],
+      "isPalette": true,
+      "passConfig": true,
+      "passReferrer": true,
+      "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
+      "url": "https://milo.adobe.com/tools/locale-nav",
+      "includePaths": [ "**.docx**" ]
     }
   ]
 }


### PR DESCRIPTION
* Organizing styles by block name and only loading block styles as needed.
* You should see two faas.css files loaded from libs/ and styles/
* More styles to come, see: [MWPW-128620](https://jira.corp.adobe.com/browse/MWPW-128620), [MWPW-129587](https://jira.corp.adobe.com/browse/MWPW-129587), and [MWPW-129585](https://jira.corp.adobe.com/browse/MWPW-129585)

Resolves: [MWPW-128620](https://jira.corp.adobe.com/browse/MWPW-128620)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/resources/6-must-haves-fast-flexible-ecommerce-platform?martech=off
- After: https://bmarshal-faas-1-col--bacom--adobecom.hlx.page/resources/6-must-haves-fast-flexible-ecommerce-platform?martech=off