### PR TITLE
MWPW-128620 loading block styles

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,6 +14,7 @@ import { setLibs } from './utils.js';
 
 const LIBS = '/libs';
 const STYLES = '/styles/styles.css';
+const BLOCK_STYLES = ['faas'];
 const CONFIG = {
   imsClientId: 'bacom',
   local: {
@@ -159,6 +160,17 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
+const loadBlockStyles = (selector = 'body > main') => {
+  BLOCK_STYLES.forEach((style) => {
+    if (document.querySelector(`${selector} div.${style}`)) {
+      const link = document.createElement('link');
+      link.setAttribute('rel', 'stylesheet');
+      link.setAttribute('href', `/styles/${style}.css`);
+      document.head.appendChild(link);
+    }
+  });
+};
+
 (async function loadPage() {
   const { loadArea, loadDelayed, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
   const metaCta = document.querySelector('meta[name="chat-cta"]');
@@ -173,5 +185,6 @@ const miloLibs = setLibs(LIBS);
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom' });
   await loadArea();
+  loadBlockStyles();
   loadDelayed();
 }());


### PR DESCRIPTION
* Organizing styles by block name and only loading block styles as needed.
* You should see two faas.css files loaded from libs/ and styles/
* More styles to come, see: [MWPW-128620](https://jira.corp.adobe.com/browse/MWPW-128620), [MWPW-129587](https://jira.corp.adobe.com/browse/MWPW-129587), and [MWPW-129585](https://jira.corp.adobe.com/browse/MWPW-129585)

Resolves: [MWPW-128620](https://jira.corp.adobe.com/browse/MWPW-128620)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/resources/6-must-haves-fast-flexible-ecommerce-platform?martech=off
- After: https://bmarshal-faas-1-col--bacom--adobecom.hlx.page/resources/6-must-haves-fast-flexible-ecommerce-platform?martech=off
