### PR TITLE
MWPW-129397 Clearbit FaaS Enabled Styles

### DIFF
--- a/styles/faas.css
+++ b/styles/faas.css
@@ -186,7 +186,8 @@
 /** Non next styles above -- remove line later **/
 
 .faas.next {
-  min-width: 600px;
+  /* min-width: 600px; */
+  padding: 0;
 }
 
 .faas-form.next {
@@ -200,17 +201,20 @@
   width: 100%;
   flex-grow: 1;
   justify-content: left;
+  padding: 0;
 }
 
 .faas-form.next .FaaS-1 label { /* stylelint-disable-line */
   min-width: unset;
   flex-shrink: 1;
   width: fit-content;
+  padding-right: 20px;
 }
 
 .faas.next .faas-form.next .textfield.FaaS-1 input { /* stylelint-disable-line */
   min-width: unset;
   max-width: unset;
+  flex-grow: 2;
 }
 
 .faas.next .faas-form .row.submit input + div::after {

--- a/styles/faas.css
+++ b/styles/faas.css
@@ -1,3 +1,24 @@
+.resource-form .columns {
+  max-width: unset;
+}
+
+.resource-form .columns .row {
+  display: flex;
+  flex-direction: column;
+}
+
+.faas.next {
+  box-shadow: none;
+}
+
+.faas.next .faas-form {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: column;
+}
+
+/** next styles above due to specificity, form specific styles below **/
+
 .faas-form-79.faas.column2,
 .faas-form-63.faas.column2,
 .faas-form-21.faas.column2 {
@@ -51,6 +72,20 @@
   font-family: var(--body-font-family);
   font-size: var(--type-body-s-size);
   line-height: 20px;
+}
+
+.faas.next .faas-form .row.submit.next input {
+  color: #FFF;
+  background: var(--color-accent);
+  border: 2px solid var(--color-accent);
+  padding: 7px 18px 8px;
+  line-height: 20px;
+  border-radius: 20px;
+  font-size: 17px;
+  min-height: 21px;
+  margin: 0;
+  grid-column: 2 / 3;
+  width: 32px;
 }
 
 .faas-form-79.faas.column2 .faas-form input:not([type=checkbox]):not([type=radio]):not([type=submit]),
@@ -175,25 +210,7 @@
   }
 }
 
-@media screen and (min-width: 900px) {
-  .faas-form-79.faas.column2,
-  .faas-form-63.faas.column2,
-  .faas-form-21.faas.column2 {
-    padding: 56px 40px;
-  }
-}
-
 /** Non next styles above -- remove line later **/
-
-.faas.next {
-  box-shadow: none;
-}
-
-.faas.next .faas-form {
-  display: flex;
-  justify-content: flex-start;
-}
-
 .faas.next .faas-form-wrapper.next {
   min-height: unset !important;
 }
@@ -204,49 +221,34 @@
 
 .faas-form.next  div.textfield.row.FaaS-1 { /* stylelint-disable-line */
   display: flex;
-  flex-flow: nowrap;
-  flex-direction: row;
-  width: 100%;
-  flex-grow: 1;
-  justify-content: left;
-  align-items: center;
-  padding: 0;
-  margin-bottom: 32px;
+  flex-flow: row wrap;
+  width: 100% !important;
 }
 
 .faas-form.next .FaaS-1 label { /* stylelint-disable-line */
-  min-width: unset;
-  flex-shrink: 1;
   width: fit-content;
   padding-right: 20px;
-  margin-bottom: 0;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
 }
 
 .faas.next .faas-form.next .textfield.FaaS-1 input { /* stylelint-disable-line */
-  min-width: unset;
-  max-width: unset;
-  flex-grow: 2;
+  display: grid;
+  grid-column: 2 / 4;
 }
 
 .faas.next .faas-form .row.submit input + div::after {
-  content: unset;
+  /* content: unset; */
+  opacity: 0;
 }
 
 .faas.next .faas-form .row.submit.next {
   align-self: flex-start;
   padding: 0;
-}
-
-.faas.next .faas-form .row.submit.next input {
-  color: #FFF;
-  background: var(--color-accent);
-  border: 2px solid var(--color-accent);
-  padding: 7px 18px 8px;
-  line-height: 20px;
-  border-radius: 20px;
-  font-size: 17px;
-  min-height: 21px;
-  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  width: 100%;
 }
 
 .faas.next .faas-form .row.submit.next input:hover {
@@ -268,9 +270,31 @@
     margin-left: unset;
     margin-right: unset;
   }
+
+  .faas-form.next  div.textfield.row.FaaS-1 { /* stylelint-disable-line */
+    display: grid;
+    width: 100% !important;
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  .faas-form.next .FaaS-1 label { /* stylelint-disable-line */
+    margin-bottom: 0;
+  }
+}
+
+@media screen and (min-width: 900px) {
+  .faas-form-79.faas.column2,
+  .faas-form-63.faas.column2,
+  .faas-form-21.faas.column2 {
+    padding: 56px 40px;
+  }
 }
 
 @media screen and (min-width: 1200px) {
+  .resource-form .columns .row {
+    flex-direction: row;
+  }
+  
   .faas.next {
     padding: 56px 72px;
     min-width: 600px;

--- a/styles/faas.css
+++ b/styles/faas.css
@@ -182,3 +182,58 @@
     padding: 56px 40px;
   }
 }
+
+/** Non next styles above -- remove line later **/
+
+.faas.next {
+  min-width: 600px;
+}
+
+.faas-form.next {
+  flex-direction: column;
+}
+
+.faas-form.next  div.textfield.row.FaaS-1 { /* stylelint-disable-line */
+  display: flex;
+  flex-flow: nowrap;
+  flex-direction: row;
+  width: 100%;
+  flex-grow: 1;
+  justify-content: left;
+}
+
+.faas-form.next .FaaS-1 label { /* stylelint-disable-line */
+  min-width: unset;
+  flex-shrink: 1;
+  width: fit-content;
+}
+
+.faas.next .faas-form.next .textfield.FaaS-1 input { /* stylelint-disable-line */
+  min-width: unset;
+  max-width: unset;
+}
+
+.faas.next .faas-form .row.submit input + div::after {
+  content: unset;
+}
+
+.faas.next .faas-form .row.submit.next {
+  align-self: flex-start;
+}
+
+.faas.next .faas-form .row.submit.next input {
+  color: #FFF;
+  background: var(--color-accent);
+  border: 2px solid var(--color-accent);
+  padding: 7px 18px 8px;
+  line-height: 20px;
+  border-radius: 20px;
+  font-size: 17px;
+  min-height: 21px;
+  margin: 0;
+}
+
+.faas.next .faas-form .row.submit.next input:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}

--- a/styles/faas.css
+++ b/styles/faas.css
@@ -186,12 +186,20 @@
 /** Non next styles above -- remove line later **/
 
 .faas.next {
-  /* min-width: 600px; */
-  padding: 0;
+  box-shadow: none;
 }
 
-.faas-form.next {
-  flex-direction: column;
+.faas.next .faas-form {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.faas.next .faas-form-wrapper.next {
+  min-height: unset !important;
+}
+
+.faas.next .faas-title {
+  margin-bottom: 32px;
 }
 
 .faas-form.next  div.textfield.row.FaaS-1 { /* stylelint-disable-line */
@@ -201,7 +209,9 @@
   width: 100%;
   flex-grow: 1;
   justify-content: left;
+  align-items: center;
   padding: 0;
+  margin-bottom: 32px;
 }
 
 .faas-form.next .FaaS-1 label { /* stylelint-disable-line */
@@ -209,6 +219,7 @@
   flex-shrink: 1;
   width: fit-content;
   padding-right: 20px;
+  margin-bottom: 0;
 }
 
 .faas.next .faas-form.next .textfield.FaaS-1 input { /* stylelint-disable-line */
@@ -223,6 +234,7 @@
 
 .faas.next .faas-form .row.submit.next {
   align-self: flex-start;
+  padding: 0;
 }
 
 .faas.next .faas-form .row.submit.next input {
@@ -240,4 +252,31 @@
 .faas.next .faas-form .row.submit.next input:hover {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
+}
+
+.mobile-max-width.next {
+  margin-left: calc(var(--grid-margins-width) * -1 / 2);
+  margin-right: calc(var(--grid-margins-width) * -1 / 2);
+}
+
+@media screen and (min-width: 600px) {
+  .section.two-up.xxl-spacing.next {
+    grid-template-columns: 1fr;
+  }
+
+  .mobile-max-width.next {
+    margin-left: unset;
+    margin-right: unset;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .faas.next {
+    padding: 56px 72px;
+    min-width: 600px;
+  }
+
+  .section.two-up.xxl-spacing.next {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }


### PR DESCRIPTION
* Adds FaaS Clearbit Enabled styles based on work expected to be merged into milo: https://github.com/adobecom/milo/pull/686

Resolves: [MWPW-129585](https://jira.corp.adobe.com/browse/MWPW-129585)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/faas-pages/forrester-wave-copy?martech=off
- After: https://clearbit-faas-next-styles--bacom--adobecom.hlx.page/drafts/slavin/faas-pages/forrester-wave-copy?martech=off
