### PR TITLE
MWPW-130076 Resource Index Text Selector

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -455,6 +455,6 @@ indices:
     properties:
       <<: *defaultProps
       faas-url:
-        select: .columns div div a, .text.contained div div a
+        select: .columns div div a, .text div div a
         value: |
           attribute(el, 'href')


### PR DESCRIPTION
* Update the selector for the US Resource index to allow for text blocks that don't have "contained"

Resolves: [MWPW-130076](https://jira.corp.adobe.com/browse/MWPW-130076)

**Test URLs:**
N/A
