### PR TITLE
Eager load all marquee images

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -139,7 +139,7 @@ const eagerLoad = (img) => {
 
 // Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const firstDiv = document.querySelector('body > main > div:nth-child(1) > div');
+  const firstDiv = document.querySelector('body > main > div:first-child > div');
   if (firstDiv?.classList.contains('marquee')) {
     firstDiv.querySelectorAll('img').forEach(eagerLoad);
   } else {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -132,11 +132,18 @@ const CONFIG = {
   ],
 };
 
+const eagerLoad = (img) => {
+  img?.setAttribute('loading', 'eager');
+  img?.setAttribute('fetchpriority', 'high');
+};
+
 // Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const lcpImg = document.querySelector('img');
-  if (lcpImg) {
-    lcpImg.setAttribute('loading', 'eager');
+  const firstDiv = document.querySelector('body > main > div:nth-child(1) > div');
+  if (firstDiv?.classList.contains('marquee')) {
+    firstDiv.querySelectorAll('img').forEach(eagerLoad);
+  } else {
+    eagerLoad(document.querySelector('img'));
   }
 }());
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -137,11 +137,10 @@ const eagerLoad = (img) => {
   img?.setAttribute('fetchpriority', 'high');
 };
 
-// Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const firstDiv = document.querySelector('body > main > div:first-child > div');
-  if (firstDiv?.classList.contains('marquee')) {
-    firstDiv.querySelectorAll('img').forEach(eagerLoad);
+  const marquee = document.querySelector('.marquee');
+  if (marquee) {
+    marquee.querySelectorAll('img').forEach(eagerLoad);
   } else {
     eagerLoad(document.querySelector('img'));
   }


### PR DESCRIPTION
When there are multiple images in the marquee at the top of the page, only the first image in the marquee is eager loaded.  In many cases the first image is a very small image and the 2nd image is the main background image, which should also be eager loaded.

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study?martech=off
- After: https://c3-eager--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study?martech=off

To test:
* Inspect the HH logo in the marquee.  In both branches that is eager loaded
* Inspect the skier image in the marquee.  In main the image is lazy loaded, in c3-eager the image is now eager loaded.