### PR TITLE
MWPW-132434 Remove CIS geos from index and sitemap

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -161,24 +161,6 @@ indices:
     target: /ch_it/query-index.xlsx
     properties:
       <<: *minProps
-  sitemap-cis_en:
-    include:
-      - '/cis_en/customer-success-stories/**'
-      - '/cis_en/resources/**'
-    exclude:
-      - '**/fragments/**'
-    target: /cis_en/query-index.xlsx
-    properties:
-      <<: *minProps
-  sitemap-cis_ru:
-    include:
-      - '/cis_ru/customer-success-stories/**'
-      - '/cis_ru/resources/**'
-    exclude:
-      - '**/fragments/**'
-    target: /cis_ru/query-index.xlsx
-    properties:
-      <<: *minProps
   sitemap-cl:
     include:
       - '/cl/customer-success-stories/**'
@@ -856,16 +838,6 @@ indices:
     include:
       - '/ch_it/customer-success-stories/**'
     target: /ch_it/customer-success-stories/query-index.xlsx
-  customer-success-stories-cis_en:
-    <<: *default
-    include:
-      - '/cis_en/customer-success-stories/**'
-    target: /cis_en/customer-success-stories/query-index.xlsx
-  customer-success-stories-cis_ru:
-    <<: *default
-    include:
-      - '/cis_ru/customer-success-stories/**'
-    target: /cis_ru/customer-success-stories/query-index.xlsx
   customer-success-stories-cl:
     <<: *default
     include:

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -96,32 +96,6 @@ sitemaps:
         alternate: /ch_it/{path}.html
         destination: /ch_it/sitemap.xml
         hreflang: it-CH
-      cis_en:
-        source: /cis_en/query-index.json
-        alternate: /cis_en/{path}.html
-        destination: /cis_en/sitemap.xml
-        hreflang:
-          - en-AM
-          - en-AZ
-          - en-BY
-          - en-KG
-          - en-KZ
-          - en-MD
-          - en-TJ
-          - en-UZ
-      cis_ru:
-        source: /cis_ru/query-index.json
-        alternate: /cis_ru/{path}.html
-        destination: /cis_ru/sitemap.xml
-        hreflang:
-          - ru-AM
-          - ru-AZ
-          - ru-BY
-          - ru-KG
-          - ru-KZ
-          - ru-MD
-          - ru-TJ
-          - ru-UZ
       cl:
         source: /cl/query-index.json
         alternate: /cl/{path}.html

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -52,12 +52,6 @@
     <loc>https://business.adobe.com/ch_it/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://business.adobe.com/cis_en/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://business.adobe.com/cis_ru/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://business.adobe.com/cl/sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
* Removing cis_en and cis_ru from the indexes and sitemaps because those geos are no longer active

Resolves: [MWPW-132434](https://jira.corp.adobe.com/browse/MWPW-132434)

**Test URLs:**
N/A
