### PR TITLE
MWPW-133230 why-adobe and support for US sitemap

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -5,6 +5,8 @@ indices:
     include:
       - '/customer-success-stories/**'
       - '/resources/**'
+      - '/why-adobe/**'
+      - '/support/**'
     exclude:
       - '**/fragments/**'
     target: /query-index.xlsx


### PR DESCRIPTION
 - Add /why-adobe and /support folders to US sitemap index
 - Follow up from #126 

Resolves: [MWPW-133230](https://jira.corp.adobe.com/browse/MWPW-133230)

Test URLs:
N/A