### PR TITLE
MWPW-133167 CaaS CLS Issue

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -64,6 +64,6 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 }
 
  /* CaaS Height Styles  */
-.caas-spacing-s {
-  min-height: 300px;
+.caas-spacing-m {
+  min-height: 500px;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -62,3 +62,12 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
     top: 10px;
   }
 }
+
+ /* CaaS Height Styles  */
+.caas-spacing-s {
+  min-height: 300px;
+}
+
+.caas-spacing-m {
+  min-height: 500px;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -67,7 +67,3 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 .caas-spacing-s {
   min-height: 300px;
 }
-
-.caas-spacing-m {
-  min-height: 500px;
-}


### PR DESCRIPTION
* Adds two classes to styles.css as overrides for CaaS min-height in section metadata. 
* The small class represents roughly the height of the half cards, the medium the full sized cards. 

###  Context
After doing some investigation, essentially loading the footer after CaaS cards load would require a change against the CaaS react components themselves, and may not be the best approach. The CaaS react component mounts to the DOM before the cards are finished fetching, and the CaaS component itself is controlled by the CaaS react components, meaning that though we could ask for an event to be added, there may occur situations in which the footer would not load.  In addition to this, since the footer is loaded in `loadArea()` changes to prevent CLS on this page would require a change that could have effects on all milo consumers. 

Because the issue was identified with resources/main on bacom, I am putting the overrides here instead of Milo, since we are not aware of who else may need them. Should it be determined styles like this are needed by the broader community, we can move them then. 

Tested via pagespeed insights on a Milo branch first to ensure that CLS was 0, moved to bacom for this PR. 

Resolves: [MWPW-133167](https://jira.corp.adobe.com/browse/MWPW-133167)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/drafts/slavin/CaaS-tests/main?martech=off
- After: https://caas-cls-issue--bacom--adobecom.hlx.live/drafts/slavin/CaaS-tests/main?martech=off
