### PR TITLE
MWPW-134103 Fix Blog Regex

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -127,8 +127,7 @@ const CONFIG = {
     { iframe: 'https://adobe.ideacloud.com' },
   ],
   htmlExclude: [
-    /business\.adobe\.com\/blog\/.*/,
-    /business\.adobe\.com\/(\w\w|(\w\w_\w\w))\/blog\/.*/,
+    /business\.adobe\.com\/(\w\w(_\w\w)?\/)?blog(\/.*)?/,
   ],
 };
 


### PR DESCRIPTION
* Updating the html exclude regular expression to include /blog with no trailing slash
* Previously `appendHtmlPostfix` was only called durring `loadArea`, but now that html postfix has been updated   `appendHtmlToLink` is called more frequently with `decorateLinks`.  https://github.com/adobecom/milo/pull/927
* The Experience Cloud blog, https://business.adobe.com/blog, does not have a trailing slash and since gnav is loading fragments, fragments/gnav/resources.plain.html, the `appendHtmlToLink` function is now ran against the blog link.
  * Note, stage works correctly because the domains do not match.

Resolves: [MWPW-134103](https://jira.corp.adobe.com/browse/MWPW-134103)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
N/A