### PR TITLE
[MWPW-134128] Webinars style patch 

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -50,10 +50,30 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   margin-bottom: var(--spacing-xxs);
 }
 
+ /* CaaS Height Styles  */
+ .caas-spacing-m {
+  min-height: 500px;
+}
+
+.milo-iframe.webinars-fix {
+  height: 4463px;
+  padding-bottom: 0;
+}
+
+@media screen and (min-width: 600px) {
+  .milo-iframe.webinars-fix {
+    height: 3078px;
+  }
+}
+
 @media screen and (min-width: 900px) {
   .text-block.text-list {
     max-width: 400px;
     box-sizing: border-box;
+  }
+
+  .milo-iframe.webinars-fix {
+    height: 3284px;
   }
 }
 
@@ -61,9 +81,8 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   .icon-headings .col img {
     top: 10px;
   }
-}
 
- /* CaaS Height Styles  */
-.caas-spacing-m {
-  min-height: 500px;
+  .milo-iframe.webinars-fix {
+    height: 2682px;
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -81,8 +81,4 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   .icon-headings .col img {
     top: 10px;
   }
-
-  .milo-iframe.webinars-fix {
-    min-height: 2682px;
-  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -82,3 +82,9 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
     top: 10px;
   }
 }
+
+@media screen and (min-width: 1440px) {
+  .milo-iframe.webinars-fix {
+    min-height: 2703px;
+  }
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -56,13 +56,13 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 }
 
 .milo-iframe.webinars-fix {
-  height: 4463px;
+  min-height: 4463px;
   padding-bottom: 0;
 }
 
 @media screen and (min-width: 600px) {
   .milo-iframe.webinars-fix {
-    height: 3078px;
+    min-height: 3078px;
   }
 }
 
@@ -73,7 +73,7 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   }
 
   .milo-iframe.webinars-fix {
-    height: 3284px;
+    min-height: 3284px;
   }
 }
 
@@ -83,6 +83,6 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   }
 
   .milo-iframe.webinars-fix {
-    height: 2682px;
+    min-height: 2682px;
   }
 }


### PR DESCRIPTION
* Adding specific class to fix resources/webinars.html, not preferred method. Requested by stakeholders
* Note, between 599px and 672px viewport width the double scrollbar issue appears. I will not add a media query for this, as this fix is already what I would consider an anti-pattern for milo. 

Resolves: [MWPW-134128](https://jira.corp.adobe.com/browse/MWPW-134128)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/webinars?martech=off
- After: https://mwpw-134128-webinars-style-patch--bacom--adobecom.hlx.page/drafts/slavin/webinars?martech=off
