### PR TITLE
MWPW-135447 Use .html for all bacom links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -129,6 +129,7 @@ const CONFIG = {
   htmlExclude: [
     /business\.adobe\.com\/(\w\w(_\w\w)?\/)?blog(\/.*)?/,
   ],
+  useDotHtml: true,
 };
 
 const eagerLoad = (img) => {


### PR DESCRIPTION
Set the `useDotHtml` flag for all of bacom.

Requires this milo pr: https://github.com/adobecom/milo/pull/1148

Resolves: [MWPW-135447](https://jira.corp.adobe.com/browse/MWPW-135447)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/?milolibs=homehtml&martech=off
- After: https://usedothtml--bacom--adobecom.hlx.page/?milolibs=homehtml&martech=off
