### PR TITLE
MWPW-135371 FaaS title center

### DIFF
--- a/styles/faas.css
+++ b/styles/faas.css
@@ -31,7 +31,7 @@
 }
 
 .resource-form .faas .faas-title {
-  margin: 0 0 18px;
+  margin-bottom: 18px;
 }
 
 .resource-form .faas .faas-title p {


### PR DESCRIPTION
* Fix resource-center styling on faas forms to allow centered title

Resolves: [MWPW-135371](https://jira.corp.adobe.com/browse/MWPW-135371)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/drafts/atierney/test1?martech=off
- After: https://methomas-faas-heading--bacom--adobecom.hlx.live/drafts/atierney/test1?martech=off

For regression:
- https://methomas-faas-heading--bacom--adobecom.hlx.page/
- https://methomas-faas-heading--bacom--adobecom.hlx.page/resources/reports/gartner-mq-personalization-engines-2023