### PR TITLE
MWPW-134192-Add caas and faas configurator to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -91,6 +91,24 @@
       "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 498px; width: 460px;",
       "includePaths": [ "**.docx**", "**.xlsx**" ]
+    },
+    {
+      "containerId": "tools",
+      "id": "caas-configurator",
+      "title": "CaaS Configurator",
+      "environments": [ "edit", "preview", "dev" ],
+      "url": "https://milo.adobe.com/tools/caas",
+      "isPalette": false,
+      "includePaths": [ "**.docx**"]
+    },
+    {
+      "containerId": "tools",
+      "id": "faas-configurator",
+      "title": "FaaS Configurator",
+      "environments": [ "edit", "preview", "dev" ],
+      "url": "https://milo.adobe.com/tools/faas",
+      "isPalette": false,
+      "includePaths": [ "**.docx**"]
     }
   ]
 }


### PR DESCRIPTION
* Add links to CaaS and FaaS configurator to the sidekick
* Link to these configurators has been added under Tools
* Configurator page will open in a new tab in browser

Resolves: [MWPW-134192](https://jira.corp.adobe.com/browse/MWPW-134192)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/?martech=off
- After: https://sidekick--bacom--ruchika4.hlx.page/?martech=off
