### PR TITLE
MWPW-139001 - Adjust LCP Image Loading

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -138,7 +138,7 @@ const eagerLoad = (img) => {
 };
 
 (async function loadLCPImage() {
-  const marquee = document.querySelector('.marquee');
+  const marquee = document.querySelector('.marquee.split');
   if (marquee) {
     marquee.querySelectorAll('img').forEach(eagerLoad);
   } else {


### PR DESCRIPTION
* Only load all images if the marquee has a split variant

Resolves: [MWPW-139001](https://jira.corp.adobe.com/browse/MWPW-139001)

---

### Split Marquee test URLs
- [Before](https://main--bacom--adobecom.hlx.live/customer-success-stories/helly-hansen-case-study?martech=off)
- [After](https://fix-eager-lcp--bacom--adobecom.hlx.live/customer-success-stories/helly-hansen-case-study?martech=off)

#### Steps to test
Observe there are two images loading in the network console...

<img width="300" alt="Screenshot 2023-11-08 at 4 04 58 PM" src="https://github.com/adobecom/bacom/assets/1972095/7ff3d3e0-1df1-46da-ab50-1faebbac92d6">

---

### Marquee (regular) test URLs
- [Before](https://main--bacom--adobecom.hlx.live/drafts/cmillar/aem-trials?martech=off)
- [After](https://fix-eager-lcp--bacom--adobecom.hlx.live/drafts/cmillar/aem-trials?martech=off)

#### Steps to test (before)
Observe there are two images loading in the network console...

<img width="300" alt="Screenshot 2023-11-08 at 4 09 10 PM" src="https://github.com/adobecom/bacom/assets/1972095/89fb642c-9830-4acc-b6e1-926e3e2ac673">

#### Steps to test (after)
Observe there is only one image loading in the network console...

<img width="300" alt="Screenshot 2023-11-08 at 4 07 18 PM" src="https://github.com/adobecom/bacom/assets/1972095/6ac4656d-66d5-4f0f-9032-8a81140218fc">
