### PR TITLE
MWPW-138379 Query index date format

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -31,7 +31,7 @@ indices:
       publishDate:
         select: head > meta[name="publishdate"]
         value: |
-          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
+          attribute(el, 'content')
   sitemap-ae_ar:
     include:
       - '/ae_ar/'


### PR DESCRIPTION
* Change format of publish date in query index to a string rather than date value. This is because some site sections have different date formats (MM-DD-YYYY vs YYYY-MM-DD)

Resolves: [MWPW-138379](https://jira.corp.adobe.com/browse/MWPW-138379)

**Test URLs:**
N/A
