### PR TITLE
MWPW-141663 - Fix BACOM Homepage Marquee LCP

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -148,9 +148,13 @@ const eagerLoad = (img) => {
 };
 
 (async function loadLCPImage() {
-  const marquee = document.querySelector('.marquee.split');
+  const marquee = document.querySelector('.marquee');
   if (marquee) {
-    marquee.querySelectorAll('img').forEach(eagerLoad);
+    if (marquee.classList.contains('split')) {
+      marquee.querySelectorAll('img').forEach(eagerLoad);
+    } else {
+      eagerLoad(marquee.querySelector('img'));
+    }
   } else {
     eagerLoad(document.querySelector('img'));
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -156,9 +156,9 @@ const eagerLoad = (img) => {
 
   if (marquee.classList.contains('split')) {
     marquee.querySelectorAll('img').forEach(eagerLoad);
-  } else {
-    eagerLoad(marquee.querySelector('img'));
+    return;
   }
+  eagerLoad(marquee.querySelector('img'));
 }());
 
 /*

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -149,14 +149,15 @@ const eagerLoad = (img) => {
 
 (async function loadLCPImage() {
   const marquee = document.querySelector('.marquee');
-  if (marquee) {
-    if (marquee.classList.contains('split')) {
-      marquee.querySelectorAll('img').forEach(eagerLoad);
-    } else {
-      eagerLoad(marquee.querySelector('img'));
-    }
-  } else {
+  if (!marquee) {
     eagerLoad(document.querySelector('img'));
+    return;
+  }
+
+  if (marquee.classList.contains('split')) {
+    marquee.querySelectorAll('img').forEach(eagerLoad);
+  } else {
+    eagerLoad(marquee.querySelector('img'));
   }
 }());
 


### PR DESCRIPTION
* Do not blindly select the first image for LCP if there is a vanilla marquee
* Maintain split marquee all image eager loading
* Maintain fallback to non-marquee first document image eager loading

Resolves: [MWPW-141663](https://jira.corp.adobe.com/browse/MWPW-141663)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://auniverseaway-patch-7--bacom--adobecom.hlx.live/?martech=off
