### PR TITLE
MWPW-142098: Ignore pink sidekick config during sync

### DIFF
--- a/.github/workflows/fg-sync-repos.yml
+++ b/.github/workflows/fg-sync-repos.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Overwrite floodgate repo files with latest from source repo
         run: |
-          rsync -av --exclude='fstab.yaml' --exclude='.github' --exclude='.git' --exclude='.idea' ./ ../bacom-pink/
+          rsync -av --exclude='fstab.yaml' --exclude='.github' --exclude='.git' --exclude='.idea' --exclude='tools/sidekick/config.json' ./ ../bacom-pink/
 
       - name: Commit and Push Changes to Floodgate Repository
         run: |


### PR DESCRIPTION
The sidekick in the pink project will be slightly different and should be ignored from getting overwritten when the git repo sync is performed. For example: The endpoint to load the Milo Localization v2 will be different for pink project.

Resolves: [MWPW-142098](https://jira.corp.adobe.com/browse/MWPW-142098)

