### PR TITLE
MWPW-142290: Update get/setLibs for stage

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,29 +19,6 @@
 /**
  * The decision engine for where to get Milo's libs from.
  */
-// export const [setLibs, getLibs] = (() => {
-//   let libs;
-//   return [
-//     (prodLibs) => {
-//       const { hostname } = window.location;
-//       const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'business.stage.adobe.com'];
-//       if (!stageEnvs.some((env) => hostname.includes(env))) {
-//         libs = prodLibs;
-//       } else {
-//         const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
-//         if (branch === 'local') {
-//           libs = 'http://localhost:6456/libs';
-//         } else if (branch.indexOf('--') > -1) {
-//           libs = `https://${branch}.hlx.live/libs`;
-//         } else {
-//           libs = `https://${branch}--milo--adobecom.hlx.live/libs`;
-//         }
-//       }
-//       return libs;
-//     }, () => libs,
-//   ];
-// })();
-
 export const [setLibs, getLibs] = (() => {
   let libs;
   return [

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,24 +19,41 @@
 /**
  * The decision engine for where to get Milo's libs from.
  */
+// export const [setLibs, getLibs] = (() => {
+//   let libs;
+//   return [
+//     (prodLibs) => {
+//       const { hostname } = window.location;
+//       const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'business.stage.adobe.com'];
+//       if (!stageEnvs.some((env) => hostname.includes(env))) {
+//         libs = prodLibs;
+//       } else {
+//         const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+//         if (branch === 'local') {
+//           libs = 'http://localhost:6456/libs';
+//         } else if (branch.indexOf('--') > -1) {
+//           libs = `https://${branch}.hlx.live/libs`;
+//         } else {
+//           libs = `https://${branch}--milo--adobecom.hlx.live/libs`;
+//         }
+//       }
+//       return libs;
+//     }, () => libs,
+//   ];
+// })();
+
 export const [setLibs, getLibs] = (() => {
   let libs;
   return [
-    (prodLibs) => {
-      const { hostname } = window.location;
-      const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'business.stage.adobe.com'];
-      if (!stageEnvs.some((env) => hostname.includes(env))) {
-        libs = prodLibs;
-      } else {
-        const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
-        if (branch === 'local') {
-          libs = 'http://localhost:6456/libs';
-        } else if (branch.indexOf('--') > -1) {
-          libs = `https://${branch}.hlx.live/libs`;
-        } else {
-          libs = `https://${branch}--milo--adobecom.hlx.live/libs`;
-        }
-      }
+    (prodLibs, location) => {
+      libs = (() => {
+        const { hostname, search } = location || window.location;
+        if (hostname.includes('business.stage.adobe.com')) return 'https://www.stage.adobe.com/libs';
+        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (branch === 'local') return 'http://localhost:6456/libs';
+        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+      })();
       return libs;
     }, () => libs,
   ];

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -48,9 +48,9 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (hostname.includes('business.stage.adobe.com')) return 'https://www.stage.adobe.com/libs';
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (branch === 'main' && hostname.includes('business.stage.adobe.com')) return 'https://www.stage.adobe.com/libs';
+        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
       })();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -26,7 +26,7 @@ export const [setLibs, getLibs] = (() => {
       libs = (() => {
         const { hostname, search } = location || window.location;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
-        if (branch === 'main' && hostname.includes('business.stage.adobe.com')) return 'https://www.stage.adobe.com/libs';
+        if (branch === 'main' && hostname === 'business.stage.adobe.com') return 'https://www.stage.adobe.com/libs';
         if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -1,0 +1,54 @@
+import { expect } from '@esm-bundle/chai';
+import { setLibs } from '../../scripts/utils.js';
+
+describe('Libs', () => {
+  it('Default Libs', () => {
+    const libs = setLibs('/libs');
+    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
+  });
+
+  it('Does not support milolibs query param on prod', () => {
+    const location = {
+      hostname: 'business.adobe.com',
+      search: '?milolibs=foo',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('/libs');
+  });
+
+  it('Supports milolibs query param', () => {
+    const location = {
+      hostname: 'localhost',
+      search: '?milolibs=foo',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('https://foo--milo--adobecom.hlx.live/libs');
+  });
+
+  it('Supports milo stage libs with stage as host', () => {
+    const location = {
+      hostname: 'business.stage.adobe.com',
+      search: '?milolibs=foo',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('https://www.stage.adobe.com/libs');
+  });
+
+  it('Supports local milolibs query param', () => {
+    const location = {
+      hostname: 'localhost',
+      search: '?milolibs=local',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('http://localhost:6456/libs');
+  });
+
+  it('Supports forked milolibs query param', () => {
+    const location = {
+      hostname: 'localhost',
+      search: '?milolibs=awesome--milo--forkedowner',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('https://awesome--milo--forkedowner.hlx.live/libs');
+  });
+});

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -28,10 +28,19 @@ describe('Libs', () => {
   it('Supports milo stage libs with stage as host', () => {
     const location = {
       hostname: 'business.stage.adobe.com',
-      search: '?milolibs=foo',
+      search: '',
     };
     const libs = setLibs('/libs', location);
     expect(libs).to.equal('https://www.stage.adobe.com/libs');
+  });
+
+  it('Does not support milo stage libs on non prod stage hosts', () => {
+    const location = {
+      hostname: 'stage--bacom--adobecom.hlx.live',
+      search: '',
+    };
+    const libs = setLibs('/libs', location);
+    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });
 
   it('Supports local milolibs query param', () => {

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { setLibs } from '../../scripts/utils.js';
 
 describe('Libs', () => {
-  it('Default Libs', () => {
+  it('Sets default Libs', () => {
     const libs = setLibs('/libs');
     expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });


### PR DESCRIPTION
* Modifies existing function to be in line with milo-college's format. 
* Adds unit tests for setLibs from milo-college
* Adds stage specific unit tests 

Question: 
Do we want "stage--bacom--adobecom.hlx.page/live" urls to point to milo stage? Currently this code has those hosts point to main milo libs. 

Resolves: [MWPW-142290](https://jira.corp.adobe.com/browse/MWPW-142290)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://update-libs-stage--bacom--adobecom.hlx.live/?martech=off
