### PR TITLE
MWPW-142290: Reverting Libs Stage Updates

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -25,9 +25,8 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        const branch = new URLSearchParams(search).get('milolibs') || 'main';
-        if (branch === 'main' && hostname === 'business.stage.adobe.com') return 'https://www.stage.adobe.com/libs';
         if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
       })();

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { setLibs } from '../../scripts/utils.js';
 
 describe('Libs', () => {
-  it('Sets default Libs', () => {
+  it('Default Libs', () => {
     const libs = setLibs('/libs');
     expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });
@@ -23,24 +23,6 @@ describe('Libs', () => {
     };
     const libs = setLibs('/libs', location);
     expect(libs).to.equal('https://foo--milo--adobecom.hlx.live/libs');
-  });
-
-  it('Supports milo stage libs with stage as host', () => {
-    const location = {
-      hostname: 'business.stage.adobe.com',
-      search: '',
-    };
-    const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://www.stage.adobe.com/libs');
-  });
-
-  it('Does not support milo stage libs on non prod stage hosts', () => {
-    const location = {
-      hostname: 'stage--bacom--adobecom.hlx.live',
-      search: '',
-    };
-    const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });
 
   it('Supports local milolibs query param', () => {

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { setLibs } from '../../scripts/utils.js';
 
 describe('Libs', () => {
-  it('Default Libs', () => {
+  it('Sets default Libs', () => {
     const libs = setLibs('/libs');
     expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });


### PR DESCRIPTION
* Updating our current libs patterns to match Milo College.
* Removing the stage logic and tests as they are not needed

Resolves: [MWPW-142290](https://jira.corp.adobe.com/browse/MWPW-142290)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://revert-stage-libs-updates--bacom--adobecom.hlx.live/?martech=off
