### PR TITLE
MWPW-143973: CLS Issue with Grid Width

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -77,7 +77,11 @@ main > .section[class*='-up'] > .content {
 main .section[class*='grid-width-'] {
   padding-left: unset;
   padding-right: unset;
-  display: block;
+  gap: 0;
+}
+
+main .section[class*='grid-width-'] .columns.contained {
+  margin: 0;
 }
 
 main .section.two-up,


### PR DESCRIPTION
* Removes `display: block` and resets two properties for the classes effected. 

Context: 
Display block is overriding the styles that Milo implements to prevent CLS. However, due to previous issues that occur with the `grid-width` classes, these styles were added to insure b.a.com pages did not break. There is a current PR to fix this in Milo, which would then necessitate us removing some of the code that was part of our hotfix. 

However, when attempting to remove some of the hotfix CSS it caused issues on other pages where the CLS issue was observed. Until the changes in Milo get verified and then merged, we may need to keep the hotfix code in place. 

See these PRs:
- https://github.com/adobecom/milo/pull/1881
- https://github.com/adobecom/bacom/pull/155
- https://github.com/adobecom/bacom/pull/151 

Resolves: [MWPW-143973](https://jira.corp.adobe.com/browse/MWPW-143973)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/drafts/cmillar/adobe-campaign
- Before: https://main--bacom--adobecom.hlx.page/products/experience-manager/digital-commerce
- Before: https://main--bacom--adobecom.hlx.live/resources/holiday-shopping-report
- Before: https://main--bacom--adobecom.hlx.page/products/analytics/adobe-analytics-benefits

- After: https://cls-fix--bacom--adobecom.hlx.live/drafts/cmillar/adobe-campaign
- After: https://cls-fix--bacom--adobecom.hlx.page/products/experience-manager/digital-commerce
- After: https://cls-fix--bacom--adobecom.hlx.live/resources/holiday-shopping-report
- After: https://cls-fix--bacom--adobecom.hlx.live/products/analytics/adobe-analytics-benefits