### PR TITLE
Fix team assignment

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -15,7 +15,7 @@ notifications:
           name: slavin
         customfield_11800: MWPW-140779 #epic link
         customfield_12900:  
-          value: 127741 # Magma team
+          value: Magma
         watchers:
           - casalino
           - jmichnow


### PR DESCRIPTION

* Team assignment value was not working per Jed's testing, changed to actual team name which is validated working for Javelin. Updating Magma to match.

Resolves: 

- [MWPW-143712](https://jira.corp.adobe.com/browse/MWPW-143712)
- [MWPW-143708](https://jira.corp.adobe.com/browse/MWPW-143708)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://thedoc31-patch-1--bacom--adobecom.hlx.live/?martech=off
