### PR TITLE
Issue #196: Add main -> stage sync workflow

### DIFF
--- a/.github/workflows/auto-merge-main-to-stage.yml
+++ b/.github/workflows/auto-merge-main-to-stage.yml
@@ -1,0 +1,23 @@
+name: PRs to main
+on: 
+  pull_request:
+    branches: [main]
+    types: [closed]
+jobs:
+  merge-main-to-stage:
+    if: github.event.pull_request.merged == true
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Git config
+      run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "github-actions"
+    - name: Merge main to stage
+      run: |
+          git fetch
+          git checkout stage
+          git pull
+          git merge --no-ff main -m "Auto-merge main to stage"
+          git push


### PR DESCRIPTION
* Adds the GH workflow from milo for syncing main -> stage after a push to main.

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://stage--bacom--adobecom.hlx.live/?martech=off
