### PR TITLE
Increase 404 tracking

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -168,7 +168,8 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
-  const { loadArea, loadLana, setConfig, createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const { loadArea, loadLana, setConfig, createTag, getMetadata } = await import(`${miloLibs}/utils/utils.js`);
+  if (getMetadata('template') === '404') window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
   const metaCta = document.querySelector('meta[name="chat-cta"]');
   if (metaCta && !document.querySelector('.chat-cta')) {
     const isMetaCtaDisabled = metaCta?.content === 'off';


### PR DESCRIPTION
### Description
Get a more [detailed signal for 404 pages](https://adobe-mwp.slack.com/archives/C0749KS9F8X/p1717077243972919).
Implements consumer changes for https://github.com/adobecom/milo/pull/2448
Resolves: [MWPW-152132](https://jira.corp.adobe.com/browse/MWPW-152132)

### Test Instructions
Going to a 404 page should have a weight of 10 for `window.hlx.rum.weight` once the milo PR is merged. (This BACOM-PR can be merged already without any influence)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://increase-404-tracking--bacom--adobecom.hlx.live/?martech=off
