### PR TITLE
MWPW-152082 - Utils to Scripts

### DIFF
--- a/blocks/comparison/comparison.js
+++ b/blocks/comparison/comparison.js
@@ -1,10 +1,10 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 /**
  * @param {Element} el
  */
 const init = async (el) => {
-  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+  const { createTag } = await import(`${LIBS}/utils/utils.js`);
   const rows = Array.from(el.querySelectorAll(':scope > div'));
   const headers = Array.from(rows.shift().children);
   const headersRow = createTag('tr');

--- a/blocks/faas-decode/faas-decode.js
+++ b/blocks/faas-decode/faas-decode.js
@@ -1,7 +1,7 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 export default async function init(el) {
-  const { createTag, parseEncodedConfig } = await import(`${getLibs()}/utils/utils.js`);
+  const { createTag, parseEncodedConfig } = await import(`${LIBS}/utils/utils.js`);
   const url = el.querySelector('a')?.href;
   const resp = await fetch(url);
 

--- a/blocks/redirects-formatter/redirects-formatter.js
+++ b/blocks/redirects-formatter/redirects-formatter.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 export const SELECT_ALL_REGIONS = 'Select All Regions';
 export const DESELECT_ALL_REGIONS = 'De-select All Regions';
@@ -12,7 +12,7 @@ const INSTRUCTIONS_TEXT = 'Select the locales you require by checking the checkb
   + ' press "Copy to clipboard" or select them with the cursor manually.';
 
 async function createLocaleCheckboxes(prefixGroup) {
-  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+  const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
   return Object.keys(prefixGroup).map((key) => {
     const { prefix } = prefixGroup[key];
@@ -87,7 +87,7 @@ export function stringifyListForExcel(urls) {
 }
 
 export default async function init(el) {
-  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+  const { createTag } = await import(`${LIBS}/utils/utils.js`);
   const xlPath = './locale-config.json';
   const resp = await fetch(xlPath);
   if (!resp.ok) return;

--- a/blocks/stats/stats.js
+++ b/blocks/stats/stats.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 async function decorateRow(row, module) {
   const { decorateLinkAnalytics } = module;
@@ -14,8 +14,8 @@ async function decorateRow(row, module) {
 }
 
 export default async function init(el) {
-  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
-  const module = await import(`${getLibs()}/martech/attributes.js`);
+  const { createTag } = await import(`${LIBS}/utils/utils.js`);
+  const module = await import(`${LIBS}/martech/attributes.js`);
 
   module.decorateBlockAnalytics(el);
   const firstRow = el.querySelector(':scope > div');

--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 const BACOM_HOSTS = ['localhost', '--bacom--adobecom.hlx.page', '--bacom--adobecom.hlx.live', 'business.adobe.com'];
 
@@ -110,7 +110,7 @@ const init = async (el) => {
 
   if (!topList) return;
 
-  const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+  const { createTag } = await import(`${LIBS}/utils/utils.js`);
   const subLists = topList.querySelectorAll('ul');
   const isAccordion = subLists.length > 0;
   const links = el.querySelectorAll('a');

--- a/blocks/workfront-login/workfront-login.js
+++ b/blocks/workfront-login/workfront-login.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
 export async function createProofForm(createTag, replaceKey, config) {
   const form = createTag('form', { action: 'https://app.proofhq.com/login', method: 'post' });
@@ -105,8 +105,8 @@ export async function createSubdomainForm(createTag, replaceKey, config) {
 
 /* c8 ignore next 14 */
 export default async function init(el) {
-  const { createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`);
-  const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
+  const { createTag, getConfig } = await import(`${LIBS}/utils/utils.js`);
+  const { replaceKey } = await import(`${LIBS}/features/placeholders.js`);
   const config = getConfig();
   const isProof = el.classList.contains('proof');
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,5 +1,3 @@
-import { setLibs } from './utils.js';
-
 const LIBS = '/libs';
 const STYLES = ['/styles/styles.css'];
 const CONFIG = {
@@ -156,6 +154,22 @@ const loadStyle = (path) => {
   }
   eagerLoad(marquee.querySelector('img'));
 }());
+
+export const [setLibs, getLibs] = (() => {
+  let libs;
+  return [
+    (prodLibs, location) => {
+      libs = (() => {
+        const { hostname, search } = location || window.location;
+        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (branch === 'local') return 'http://localhost:6456/libs';
+        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+      })();
+      return libs;
+    }, () => libs,
+  ];
+})();
 
 const miloLibs = setLibs(LIBS);
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -155,23 +155,15 @@ const loadStyle = (path) => {
   eagerLoad(marquee.querySelector('img'));
 }());
 
-export const [setLibs, getLibs] = (() => {
-  let libs;
-  return [
-    (prodLibs, location) => {
-      libs = (() => {
-        const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
-        const branch = new URLSearchParams(search).get('milolibs') || 'main';
-        if (branch === 'local') return 'http://localhost:6456/libs';
-        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
-      })();
-      return libs;
-    }, () => libs,
-  ];
-})();
+const setLibs = () => {
+  const { hostname, search } = window.location;
+  if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return LIBS;
+  const branch = new URLSearchParams(search).get('milolibs') || 'main';
+  if (branch === 'local') return 'http://localhost:6456/libs';
+  return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+};
 
-const miloLibs = setLibs(LIBS);
+const miloLibs = setLibs();
 
 (function loadStyles() {
   const paths = [`${miloLibs}/styles/styles.css`];

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,4 +1,3 @@
-const LIBS = '/libs';
 const STYLES = ['/styles/styles.css'];
 const CONFIG = {
   imsClientId: 'bacom',
@@ -155,18 +154,17 @@ const loadStyle = (path) => {
   eagerLoad(marquee.querySelector('img'));
 }());
 
-const setLibs = () => {
+// eslint-disable-next-line import/prefer-default-export
+export const LIBS = (() => {
   const { hostname, search } = window.location;
   if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return LIBS;
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
   return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
-};
-
-const miloLibs = setLibs();
+})();
 
 (function loadStyles() {
-  const paths = [`${miloLibs}/styles/styles.css`];
+  const paths = [`${LIBS}/styles/styles.css`];
   if (STYLES) {
     paths.push(...(Array.isArray(STYLES) ? STYLES : [STYLES]));
   }
@@ -174,7 +172,7 @@ const miloLibs = setLibs();
 }());
 
 (async function loadPage() {
-  const { loadArea, loadLana, setConfig, createTag, getMetadata } = await import(`${miloLibs}/utils/utils.js`);
+  const { loadArea, loadLana, setConfig, createTag, getMetadata } = await import(`${LIBS}/utils/utils.js`);
   if (getMetadata('template') === '404') window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
   const metaCta = document.querySelector('meta[name="chat-cta"]');
   if (metaCta && !document.querySelector('.chat-cta')) {
@@ -185,7 +183,7 @@ const miloLibs = setLibs();
       if (lastSection) lastSection.insertAdjacentElement('beforeend', chatDiv);
     }
   }
-  setConfig({ ...CONFIG, miloLibs });
+  setConfig({ ...CONFIG, miloLibs: LIBS });
   loadLana({ clientId: 'bacom', tags: 'info' });
   await loadArea();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -157,7 +157,7 @@ const loadStyle = (path) => {
 // eslint-disable-next-line import/prefer-default-export
 export const LIBS = (() => {
   const { hostname, search } = window.location;
-  if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return LIBS;
+  if (!['.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
   return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;

--- a/templates/featured-story/featured-story.js
+++ b/templates/featured-story/featured-story.js
@@ -2,9 +2,9 @@
 Templates - featured story
 */
 
-import { getLibs } from '../../scripts/utils.js';
+import { LIBS } from '../../scripts/scripts.js';
 
-const { createTag } = await import(`${getLibs()}/utils/utils.js`);
+const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
 function init() {
   const i = 1;


### PR DESCRIPTION
* Moves set/getLibs from utils into scripts to remove dependency for performance reasons. 

To Test:
When testing, please make sure you do the following at least: 

- test locally with `aem up`
- test the branch url (though it is in the "after")
- test by running milo libs locally, and using milo libs on our branch

Resolves: [MWPW-152082](https://jira.corp.adobe.com/browse/MWPW-152082)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://utils-to-scripts--bacom--adobecom.hlx.live/?martech=off

**Verification URLS for Consumer Blocks**

https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/chat-cta
https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/comparison-table
https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/event-speakers
https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/stats
https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/tree-view
https://utils-to-scripts--bacom--adobecom.hlx.page/docs/library/blocks/workfront-login