### PR TITLE
MWPW-153603 Remove stage mapping

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -120,15 +120,6 @@ const CONFIG = {
   geoRouting: 'on',
   productionDomain: 'business.adobe.com',
   prodDomains: ['business.adobe.com', 'www.adobe.com'],
-  stageDomainsMap: {
-    'business.adobe.com': 'business.stage.adobe.com',
-    'www.adobe.com': 'www.stage.adobe.com',
-    'learning.adobe.com': 'learning.stage.adobe.com',
-    'solutionpartners.adobe.com': 'solutionpartners.stage.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
-    'adobe.io': 'stage.adobe.io',
-    'developer.adobe.com': 'developer-stage.adobe.com',
-  },
   autoBlocks: [
     { iframe: 'https://adobe-ideacloud.forgedx.com' },
     { iframe: 'https://adobe.ideacloud.com' },


### PR DESCRIPTION
* Remove stage mapping (revert #205 )

Resolves: [MWPW-153603](https://jira.corp.adobe.com/browse/MWPW-153603)
Related: [MWPW-153692](https://jira.corp.adobe.com/browse/MWPW-153692)


**Test URLs:**
**CTA link:**

- Before: https://main--bacom--adobecom.hlx.page/in/products/marketo/attribution?martech=off
- After: https://methomas-remove-mapping--bacom--adobecom.hlx.page/in/products/marketo/attribution?martech=off

Scroll down to "Grow leads without growing your marketing spend." => Read report. 
Should link to: https://business.adobe.com/resources/reports/the-total-economic-impact-of-bizible.html 
Not the stage link: https://business.stage.adobe.com/resources/reports/the-total-economic-impact-of-bizible.html

**PDF Viewer:**

- Before: https://main--bacom--adobecom.hlx.page/resources/sdk/how-to-achieve-personalization-at-scale-in-financial-services?martech=off
- After: https://methomas-remove-mapping--bacom--adobecom.hlx.page/resources/sdk/how-to-achieve-personalization-at-scale-in-financial-services?martech=off

PDF still won't load in the "after" page because the pdf viewer key doesn't work on feature branches, but you can see in the network tab that it's correctly getting the prod link: https://business.adobe.com/content/dam/dx/us/en/resources/sdk/how-to-achieve-personalization-at-scale-in-financial-services/how-to-achieve-personalization-at-scale-in-financial-services-v2.pdf
