### PR TITLE
MWPW-154363: Add param anaylitics sandbox

### DIFF
--- a/scripts/aa-university.js
+++ b/scripts/aa-university.js
@@ -3,16 +3,21 @@ export default function registerAAUniversity() {
   const lastName = document.querySelector('input[name="LastName"]');
   const email = document.querySelector('input[name="Email"]');
   const country = document.querySelector('select[name="Country"]');
+  const group = document.querySelector('meta[name="sandboxGroup"]');
+
+  const postBody = {
+    first_name: firstName?.value,
+    last_name: lastName?.value,
+    email: email?.value,
+    university: 'none',
+    country: country?.value,
+  };
+
+  if (group) postBody.group = group.content;
 
   fetch('https://us-central1-adobe---aa-university.cloudfunctions.net/register', {
     method: 'POST',
-    body: JSON.stringify({
-      first_name: firstName?.value,
-      last_name: lastName?.value,
-      email: email?.value,
-      university: 'none',
-      country: country?.value,
-    }),
+    body: JSON.stringify(postBody),
   })
     .catch((error) => window.lana.log(`Marketo AA University Error: ${error}`));
 }

--- a/scripts/aa-university.js
+++ b/scripts/aa-university.js
@@ -3,7 +3,7 @@ export default function registerAAUniversity() {
   const lastName = document.querySelector('input[name="LastName"]');
   const email = document.querySelector('input[name="Email"]');
   const country = document.querySelector('select[name="Country"]');
-  const group = document.querySelector('meta[name="sandboxGroup"]');
+  const group = document.querySelector('meta[name="sandboxgroup"]');
 
   const postBody = {
     first_name: firstName?.value,
@@ -20,4 +20,6 @@ export default function registerAAUniversity() {
     body: JSON.stringify(postBody),
   })
     .catch((error) => window.lana.log(`Marketo AA University Error: ${error}`));
+
+  return postBody;
 }

--- a/test/scripts/aa-university.test.js
+++ b/test/scripts/aa-university.test.js
@@ -29,4 +29,20 @@ describe('AA University', async () => {
     window.fetch = ogFetch;
     window.lana = ogLana;
   });
+
+  it('Sends the group parameter with POST if found', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'sandboxgroup');
+    meta.setAttribute('content', 'group');
+    document.body.prepend(meta);
+    const body = registerAAUniversity();
+    expect(body.group).to.equal('group');
+
+    document.querySelector('meta').remove();
+  });
+
+  it('Does not send the group parameter with POST if not found', () => {
+    const body = registerAAUniversity();
+    expect(body.group).to.be.undefined;
+  });
 });

--- a/test/scripts/mocks/with-group.html
+++ b/test/scripts/mocks/with-group.html
@@ -1,0 +1,8 @@
+<meta name="sandboxgroup" content="anything">
+<input name="FirstName">Jane</input>
+<input name="LastName">Doe</input>
+<input name="Email">janedoe@email.com</input>
+<select name="Country">
+  <option value="US" selected>United States</option>
+  <option value="GB">United Kingdom</option>
+</select>

--- a/test/scripts/mocks/with-group.html
+++ b/test/scripts/mocks/with-group.html
@@ -1,8 +1,0 @@
-<meta name="sandboxgroup" content="anything">
-<input name="FirstName">Jane</input>
-<input name="LastName">Doe</input>
-<input name="Email">janedoe@email.com</input>
-<select name="Country">
-  <option value="US" selected>United States</option>
-  <option value="GB">United Kingdom</option>
-</select>


### PR DESCRIPTION
* Adds the ability to add a `sanboxgroup` metadata to the page that will send this group along with the post request. 

Context: 
This will allow for us to use this endpoint for multiple uses in the interim while we get a runtime solution up and running.  Arnfried has made the endpoint default to the original sandbox group if no group is sent with the POST request. This means by default we do not want to send a group unless it is found in the metadata. Additionally, probably a good idea for the authors to add the metadata `sandboxGroup` to the og page to have authoring parity. 

Needs to be tested with Eric. 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-154363)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/drafts/slavin/adobe-analytics-sandbox?martech=off
- After: https://add-param-anaylitics-sandbox--bacom--adobecom.hlx.live/drafts/slavin/adobe-analytics-sandbox?martech=off
