### PR TITLE
MWPW-161696 Increase smart redirect entry limit

### DIFF
--- a/scripts/redirects.js
+++ b/scripts/redirects.js
@@ -30,7 +30,7 @@ export function activateRedirects(data) {
       return acc;
     }, {}));
 }
-export async function fetchRedirects(path = '/smart-redirects.json') {
+export async function fetchRedirects(path = '/smart-redirects.json?limit=100000') {
   try {
     const response = await fetch(path);
     const redirects = await response.json();


### PR DESCRIPTION
* Increase the smart redirect limit from the default (1,000) to 100,000 entries

Resolves: [MWPW-161696](https://jira.corp.adobe.com/browse/MWPW-161696)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/uk/products/experience-manager/assets/rich-media-delivery
- After: https://methomas-redirect-limit--bacom--adobecom.hlx.page/uk/products/experience-manager/assets/rich-media-delivery
