### PR TITLE
MWPW-161697 Fix smart redirects .html issue

### DIFF
--- a/scripts/redirects.js
+++ b/scripts/redirects.js
@@ -73,7 +73,7 @@ export async function isValidRedirect(url) {
 
 export async function applyRedirects(
   redirects = fetchRedirects(),
-  path = window.location.pathname,
+  path = window.location.pathname.replace('.html', ''),
 ) {
   const redirect = await getRedirect(redirects, path, new URL(window.location.href));
   if (redirect && await isValidRedirect(redirect)) {


### PR DESCRIPTION
- stripping .html from the pathname for smart-redirects

Resolves: [MWPW-161697](https://jira.corp.adobe.com/browse/MWPW-161697)

**Test URLs:**
(Can only test .html on stage)
- https://business.stage.adobe.com/au/products/experience-manager/assets/adobe-asset-link.html
