### PR TITLE
MWPW-166673 Helix 5 upgrade fix - revert loc sidekick urls

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -35,7 +35,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.aem.page/tools/loc/index.html?project=bacom--adobecom",
+      "url": "https://milo.adobe.com/tools/loc/index.html?project=bacom--adobecom",
       "passReferrer": true,
       "includePaths": [ "**.xlsx**" ]
     },
@@ -44,7 +44,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--bacom--adobecom.aem.page/tools/loc?milolibs=locui",
+      "url": "https://main--bacom--adobecom.hlx.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
* Returns loc sidekick urls to previous state because loc is not yet ready for helix 5

Resolves: [MWPW-166673](https://jira.corp.adobe.com/browse/MWPW-166673)

**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://hlx-5--bacom--adobecom.aem.live/?martech=off
