### PR TITLE
MWPW-166673 [Helix 5 Migration] Revert sidekick config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,8 +1,6 @@
 {
   "project": "BACOM",
   "host": "business.adobe.com",
-  "previewHost": "main--bacom--adobecom.aem.page",
-  "liveHost": "main--bacom--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -54,7 +52,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--bacom--adobecom.aem.page/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--bacom--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**/:x**" ]
@@ -99,7 +97,7 @@
       "title": "Tag Selector",
       "id": "tag-selector",
       "environments": ["edit"],
-      "url": "https://main--bacom--adobecom.aem.live/tools/tag-selector",
+      "url": "https://main--bacom--adobecom.hlx.live/tools/tag-selector",
       "isPalette": true,
       "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
     },
@@ -138,7 +136,7 @@
       "id": "bulk",
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
-      "url": "https://main--bacom--adobecom.aem.page/tools/bulk"
+      "url": "https://main--bacom--adobecom.hlx.page/tools/bulk"
     },
     {
       "containerId": "tools",


### PR DESCRIPTION
* Remove `.aem.` urls from sidekick
* URLs generated upon preview should be `hlx.page` (To test, you need to set the local project configuration in the old sidekick to: https://hlx5-sidekick--bacom--adobecom.hlx.live)
* Sidekick tools should not have `.aem.` links. Will be prod or hlx urls.

Resolves: [MWPW-166673](https://jira.corp.adobe.com/browse/MWPW-166673)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://hlx5-sidekick--bacom--adobecom.hlx.live/?martech=off
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://hlx5-sidekick--bacom--adobecom.aem.live/?martech=off
