### PR TITLE
MWPW-166673 [Helix 5 Migration] Set preview url

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,8 @@
 {
   "project": "BACOM",
   "host": "business.adobe.com",
+  "previewHost": "main--bacom--adobecom.hlx.page",
+  "liveHost": "main--bacom--adobecom.hlx.live",
   "plugins": [
     {
       "id": "path",


### PR DESCRIPTION
* Explicitly set the sidekick preview and live link config to `.hlx.`
* Will have no change for authors
* Allows us to control the change from `.hlx.` to `.aem.` in sidekick instead of it being inferred from the config

Resolves: [MWPW-166673](https://jira.corp.adobe.com/browse/MWPW-166673)

**Test URLs:**
- Before: https://main--bacom--meganthecoder.hlx.live/?martech=off
- After: https://hlx5-preview-link--bacom--meganthecoder.hlx.live/?martech=off
*Need to test with the advanced local configuration in sidekick