### PR TITLE
MWPW-167216 Configure pdf for aem domains

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -5,19 +5,31 @@ const CONFIG = {
     pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
-  stage: {
-    edgeConfigId: '7d1ba912-10b6-4384-a8ff-4bfb1178e869',
-    pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
+  page: {
+    pdfViewerClientId: 'c30e0765380b47219774251d8eb80005',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
   live: {
-    pdfViewerClientId: '23bd4fff42fc4b4da38b3d89492a0abc',
+    pdfViewerClientId: '5e5a5032800f4918844f13b344f58db6',
+    pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  stage: {
+    edgeConfigId: '7d1ba912-10b6-4384-a8ff-4bfb1178e869',
+    pdfViewerClientId: '1573324fdb644866b51580fbaa5b6465',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
   prod: {
     edgeConfigId: '65acfd54-d9fe-405c-ba04-8342d6782ab0',
     pdfViewerClientId: '4520c0edfbf147158758d71d18765fec',
     pdfViewerReportSuite: 'adbadobenonacdcprod,adbadobedxprod,adbadobeprototype',
+  },
+  hlxPage: {
+    pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
+    pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  hlxLive: {
+    pdfViewerClientId: '23bd4fff42fc4b4da38b3d89492a0abc',
+    pdfViewerReportSuite: 'adbadobedxqa',
   },
   locales: {
     '': { ietf: 'en-US', tk: 'hah7vzn.css' },


### PR DESCRIPTION
* Update PDF Viewer client ids to support all domains, including aem.page and aem.live

Resolves: [MWPW-167216](https://jira.corp.adobe.com/browse/MWPW-167216)

**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/drafts/methomas/pdf-bacom-prod?martech=off
- After: https://pdf-aem--bacom--adobecom.aem.live/drafts/methomas/pdf-bacom-prod?martech=off

Note: This is not testable pre-production.