### PR TITLE
MWPW-168712 Fix Jarvis ID

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -143,7 +143,7 @@ const CONFIG = {
     '.business-graybox.adobe.com': { 'business.adobe.com': 'origin' },
   },
   jarvis: {
-    id: 'BACOMChat1–Worldwide',
+    id: 'BACOMChat1-Worldwide',
     version: '1.0',
     onDemand: false,
   },


### PR DESCRIPTION
* Correct jarvis chat id

Resolves: [MWPW-168712](https://jira.corp.adobe.com/browse/MWPW-168712)

**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://jarvis--bacom--meganthecoder.aem.live/?martech=off

*This is not testable on a feature branch