### PR TITLE
Added singn in button style similar like for unav sign in button

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -38,6 +38,25 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   margin-bottom: var(--spacing-xxs);
 }
 
+.global-navigation .feds-profile > .feds-signIn {
+  --feds-signIn-borderColor: #dadada;
+  padding: 5px 16px 6px;
+  line-height: 16.8px;
+  border: 2px solid var(--feds-signIn-borderColor);
+  border-radius: 16px;
+  margin-right: 8px;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.global-navigation .feds-profile > .feds-signIn:hover {
+  --feds-signIn-bgColor-hover: #e9e9e9;
+  --feds-signIn-borderColor-hover: #c6c6c6;
+  color: var(--text-color);
+  background: var(--feds-signIn-bgColor-hover);
+  border-color: var(--feds-signIn-borderColor-hover);
+}
+
 @media screen and (min-width: 900px) {
   .text-block.text-list {
     max-width: 400px;
@@ -48,6 +67,9 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 @media screen and (min-width: 1200px) {
   .icon-headings .col img {
     top: 10px;
+  }
+  .global-navigation .feds-profile > .feds-signIn {
+    margin-right: 0;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .white-columns .columns > .row {
   padding: 80px 0;
 }
@@ -65,6 +66,7 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
   .icon-headings .col img {
     top: 10px;
   }
+
   .global-navigation .feds-profile > .feds-signIn {
     margin-right: 0;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,10 +39,9 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 }
 
 .global-navigation .feds-profile > .feds-signIn {
-  --feds-signIn-borderColor: #dadada;
   padding: 5px 16px 6px;
   line-height: 16.8px;
-  border: 2px solid var(--feds-signIn-borderColor);
+  border: 2px solid #dadada;
   border-radius: 16px;
   margin-right: 8px;
   font-weight: 700;
@@ -50,11 +49,9 @@ div[class*='-up'] .con-block.has-bg.text-block.text-list,
 }
 
 .global-navigation .feds-profile > .feds-signIn:hover {
-  --feds-signIn-bgColor-hover: #e9e9e9;
-  --feds-signIn-borderColor-hover: #c6c6c6;
   color: var(--text-color);
-  background: var(--feds-signIn-bgColor-hover);
-  border-color: var(--feds-signIn-borderColor-hover);
+  background: #e9e9e9;
+  border-color: #c6c6c6;
 }
 
 @media screen and (min-width: 900px) {


### PR DESCRIPTION
We have styled the sign-in button to matched with UNAV sign in button stylings. This change is only needed for the Bacom sign-in button since Bacom does not use the UNAV. Therefore, we applied this change specifically within the Bacom codebase.
Before:
<img width="1800" alt="Screenshot 2025-03-07 at 12 38 12 PM" src="https://github.com/user-attachments/assets/467d0031-ba42-4e03-96e4-ad7c61d94418" />

After:
<img width="1800" alt="Screenshot 2025-03-07 at 12 38 19 PM" src="https://github.com/user-attachments/assets/b13cb3db-f512-4195-bc3c-2e61d65a2ddf" />

Resolves: [MWPW-167349](https://jira.corp.adobe.com/browse/MWPW-167349)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://mwpw-167349--bacom--adobecom.aem.live/?martech=off
