### PR TITLE
MWPW-161864 Fix grid width mobile gutters

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -83,12 +83,6 @@ main > .section[class*='-up'] > .content {
   margin: 0;
 }
 
-main .section[class*='grid-width-'] {
-  padding-left: unset;
-  padding-right: unset;
-  display: block;
-}
-
 main .section.two-up,
 main .section.three-up,
 main .section.four-up,
@@ -96,6 +90,16 @@ main .section.five-up {
   display: grid;
   padding-left: var(--grid-margins-width);
   padding-right: var(--grid-margins-width);
+}
+
+main .section.grid-width-12.milo-card-section {
+  padding-left: unset;
+  padding-right: unset;
+}
+
+main .section[class*='grid-width-'] .columns.contained {
+  width: 100%;
+  max-width: 100%;
 }
 
 @media screen and (min-width: 1200px) {


### PR DESCRIPTION
* Remove code that prevented left/right spacing on mobile and tablet when section metadata has `grid-width-*` classes

Resolves: [MWPW-161864](https://jira.corp.adobe.com/browse/MWPW-161864)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/mkhare/grid-width-8
- After: https://grid-8--bacom--meganthecoder.hlx.page/drafts/mkhare/grid-width-8

**Note:** We've tried to address grid widths before (#151 , #155) and it's very prone to causing regression issues. This should be tested broadly

Regression:
Homepage:
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://grid-8--bacom--meganthecoder.aem.live/?martech=off

Holiday Report:
- Before: https://main--bacom--adobecom.aem.live/resources/holiday-shopping-report?martech=off
- After: https://grid-8--bacom--meganthecoder.aem.live/resources/holiday-shopping-report?martech=off

Digital Price Index:
- Before: https://main--bacom--adobecom.aem.live/resources/digital-price-index?martech=off
- After: https://grid-8--bacom--meganthecoder.aem.live/resources/digital-price-index?martech=off

Digital Commerce (columns block with images):
- Before: https://main--bacom--adobecom.aem.live/products/experience-manager/digital-commerce?martech=off
- After: https://grid-8--bacom--meganthecoder.aem.live/products/experience-manager/digital-commerce?martech=off

Campaign Benefits (card block - consonant cards):
- Before: https://main--bacom--adobecom.aem.live/products/campaign/benefits?martech=off
- After: https://grid-8--bacom--meganthecoder.aem.live/products/campaign/benefits?martech=off

