### PR TITLE
MWPW-166978: Harden github workflows

### DIFF
--- a/.github/workflows/auto-merge-main-to-stage.yml
+++ b/.github/workflows/auto-merge-main-to-stage.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Set Git config
       run: |
           git config user.email "github-actions@github.com"

--- a/.github/workflows/code-compatibility.yaml
+++ b/.github/workflows/code-compatibility.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Check for unsupported functions
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -48,7 +48,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -61,6 +61,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/fg-sync-repos.yml
+++ b/.github/workflows/fg-sync-repos.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         with:
           app-id: ${{ secrets.FG_SYNC_APP_ID }}
           private-key: ${{ secrets.FG_SYNC_APP_PRIVATE_KEY }}
@@ -30,7 +30,7 @@ jobs:
           repositories: "bacom-pink"
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.syncBranch || github.ref_name }}
 

--- a/.github/workflows/graybox-sync-repos.yml
+++ b/.github/workflows/graybox-sync-repos.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         with:
           app-id: ${{ secrets.FG_SYNC_APP_ID }}
           private-key: ${{ secrets.FG_SYNC_APP_PRIVATE_KEY }}
@@ -30,7 +30,7 @@ jobs:
           repositories: "bacom-graybox"
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
           ref: ${{ inputs.syncBranch || github.ref_name }}

--- a/.github/workflows/listen-to-publish-events.yaml
+++ b/.github/workflows/listen-to-publish-events.yaml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         node-version: 18
 

--- a/.github/workflows/run-e2e-daily.yaml
+++ b/.github/workflows/run-e2e-daily.yaml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: adobecom/nala
           ref: main
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -10,9 +10,9 @@ jobs:
     name: Running eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18
 
@@ -20,7 +20,7 @@ jobs:
         run: npm install
 
       - name: Run eslint on changed files
-        uses: tj-actions/eslint-changed-files@v20
+        uses: tj-actions/eslint-changed-files@74f98653675512158746d3136cd2d9326fbfb6e1
         with:
           config_path: ".eslintrc.js"
           # ignore_path: "/path/to/.eslintignore"

--- a/.github/workflows/run-nala.yaml
+++ b/.github/workflows/run-nala.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala
         uses: adobecom/nala@main
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,12 +14,12 @@ jobs:
         node-version: [20.x]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -33,7 +33,7 @@ jobs:
       run: xvfb-run -a npm test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info


### PR DESCRIPTION
Following this [incident](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066) we want to harden the security for our Github actions by [pinning actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to full length commit SHAs. Its the recommended approach in terms of security from Github and while we won't get any minor versions OOTB, security and stability is more important than the latest and greatest features in this case.

Resolves: [MWPW-169978](https://jira.corp.adobe.com/browse/MWPW-169978)

Actions
Checkout https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
CodeQL https://github.com/github/codeql-action/commit/6bb031afdd8eb862ea3fc1848194185e076637e5
Github script https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
Dorny paths https://github.com/dorny/paths-filter/commit/de90cc6fb38fc0963ad72b210f1f284cd68cea36
Create-github-app-token https://github.com/actions/create-github-app-token/commit/21cfef2b496dd8ef5b904c159339626a10ad380e
Stale https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639
Setup-node https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
eslint-changed-files https://github.com/tj-actions/eslint-changed-files/commit/74f98653675512158746d3136cd2d9326fbfb6e1
Upload-artifact https://github.com/actions/upload-artifact/commit/4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
Setup-python https://github.com/actions/setup-python/commit/42375524e23c412d93fb67b49958b491fce71c38
Codecov action https://github.com/codecov/codecov-action/commit/0565863a31f2c772f9f0395002a31e3f06189574

Further details
What I've done is getting the SHA for the latest release of each action https://github.com/actions/checkout/releases ... if we ever need to update, we should always try to look for the latest SHA of a release (*that is NOT coming from a fork)

Resolves: [MWPW-169978](https://jira.corp.adobe.com/browse/MWPW-169978)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://harden-workflows--bacom--adobecom.aem.live/?martech=off
