### PR TITLE
Fixing workflow bug

### DIFF
--- a/.github/workflows/listen-to-publish-events.yaml
+++ b/.github/workflows/listen-to-publish-events.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Set up Node.js
-      uses: actions/setup-node@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: 18
 


### PR DESCRIPTION
* Adds the correct hash for setup-node since current hash was failing 


<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://stage--bacom--adobecom.aem.live/?martech=off
