### PR TITLE
MWPW-166673 [Helix 5 Migration] Update sidekick urls

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,8 +1,8 @@
 {
   "project": "BACOM",
   "host": "business.adobe.com",
-  "previewHost": "main--bacom--adobecom.hlx.page",
-  "liveHost": "main--bacom--adobecom.hlx.live",
+  "previewHost": "main--bacom--adobecom.aem.page",
+  "liveHost": "main--bacom--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -44,7 +44,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--bacom--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--bacom--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -54,7 +54,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--bacom--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--bacom--adobecom.aem.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**/:x**" ]
@@ -99,7 +99,7 @@
       "title": "Tag Selector",
       "id": "tag-selector",
       "environments": ["edit"],
-      "url": "https://main--bacom--adobecom.hlx.live/tools/tag-selector",
+      "url": "https://main--bacom--adobecom.aem.live/tools/tag-selector",
       "isPalette": true,
       "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
     },
@@ -138,7 +138,7 @@
       "id": "bulk",
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
-      "url": "https://main--bacom--adobecom.hlx.page/tools/bulk"
+      "url": "https://main--bacom--adobecom.aem.page/tools/bulk"
     },
     {
       "containerId": "tools",


### PR DESCRIPTION
* Update preview url and tools urls in sidekick from `.hlx.` to `.aem.`

Resolves: [MWPW-166673](https://jira.corp.adobe.com/browse/MWPW-166673)

**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://sidekick-aem--bacom--meganthecoder.aem.live/?martech=off
