### PR TITLE
Dont error for unfound assets for the auto importer

### DIFF
--- a/.github/workflows/import/daFetch.js
+++ b/.github/workflows/import/daFetch.js
@@ -26,9 +26,9 @@ async function getImsToken() {
 let token
 export const daFetch = async (url, opts = {}) => {
   opts.headers ||= {};
-  console.log("Fetching IMS token")
+  if(!token) console.log("Fetching IMS token")
   token = token || await getImsToken();
-  console.log("Fetched IMS token")
+  if(!token) console.log("Fetched IMS token")
   opts.headers.Authorization = `Bearer ${token}`;
   const resp = await fetch(url, opts);
   if(!resp.ok) throw new Error("DA import failed")

--- a/.github/workflows/import/index.js
+++ b/.github/workflows/import/index.js
@@ -33,7 +33,6 @@ async function importMedia(pageUrl, text) {
   const results = dom.window.document.body.querySelectorAll(LINK_SELECTORS.join(', '));
   const linkedMedia = [...results].reduce((acc, a) => {
     let href = a.getAttribute('href') || a.getAttribute('alt');
-
     // Don't add any off origin content.
     const isSameDomain = prefixes.some((prefix) => href.startsWith(prefix));
     if (!isSameDomain) return acc;
@@ -42,7 +41,6 @@ async function importMedia(pageUrl, text) {
 
     // Match the URL and remove extras
     href = href.match(/^[^?#| ]+/)[0];
-
     // Convert relative to current project origin
     const url = new URL(href);
 
@@ -69,7 +67,6 @@ async function importMedia(pageUrl, text) {
 }
 
 async function saveAllToDa(url, blob) {
-  console.log("Saving the document itself to DA")
   const { destPath, editPath, route } = url;
 
   url.daHref = `https://da.live${route}#/${toOrg}/${toRepo}${editPath}`;
@@ -94,8 +91,14 @@ async function previewOrPublish({path, action}) {
   const previewUrl = `https://admin.hlx.page/${action}/${toOrg}/${toRepo}/main${path}`;
   const opts = { method: 'POST' };
   const resp = await fetch(previewUrl, opts);
-  if (!resp.ok) throw new Error(`Failed to post to preview: ${resp.statusText}`)
-  console.log(`Posted to ${action} successfully ${action}/${toOrg}/${toRepo}/main${path}`);
+  if (!resp.ok){
+    console.log(`Posting to ${action} failed. ${action}/${toOrg}/${toRepo}/main${path}`);
+    await slackNotification(
+      `Failed ${action}/${toOrg}/${toRepo}/main${path}. Error: ${resp.status} ${resp.statusText}`
+    );
+  } else {
+    console.log(`Posted to ${action} successfully ${action}/${toOrg}/${toRepo}/main${path}`);
+  }
 }
 
 const slackNotification = (text) => {


### PR DESCRIPTION
Don't error for when we don't find assets. Erroring will currently stop the process, but if we try to import something from production - which is already available elsewhere (e.g. AEM Assets or old AEM) - we can safely ignore these errors and simply notify us on slack.

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://dont-error-when-not-finding-assets--bacom--adobecom.aem.live/?martech=off
