### PR TITLE
Fix an undefined error

### DIFF
--- a/.github/workflows/import/index.js
+++ b/.github/workflows/import/index.js
@@ -39,7 +39,7 @@ async function importMedia(pageUrl, text) {
   // const pattern = /https:\/\/[^"'\s]+\.(?:svg|mp4|pdf)/g;
   // const results = text.match(pattern) ?
   const matches = text.match(LINK_SELECTOR_REGEX)?.map((svgUrl) => {
-    const a = window.document.createElement('a');
+    const a = dom.window.document.createElement('a');
     a.href = svgUrl;
     return a;
   }) || [];


### PR DESCRIPTION
Fixes a small error in the auto importer which differentiates from the nexter importer as we use JSDOM. Seen this error pop up the last few days in the slack messages and will manually imported articles that were affected by this JS-Error

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://fix-window-undef-err--bacom--adobecom.aem.live/?martech=off
