### PR TITLE
[MWPW-169383] Some stage pages are loading code from `aem.live`

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -189,6 +189,7 @@ export function setLibs(location) {
   if (!['.hlx.', '.aem.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
+  if (branch === 'main') return `${window.location.origin}/libs`
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -189,7 +189,7 @@ export function setLibs(location) {
   if (!['.hlx.', '.aem.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
-  if (branch === 'main') return `${window.location.origin}/libs`
+  if (branch === 'main') return `${window.location.origin}/libs`;
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 }
 


### PR DESCRIPTION
**Description**
STAGE environments are fetching code from `aem.live` which will introduce an additional DNS request and might confuse engineers / authoring when they are investigating issues.

Resolves: [MWPW-169383](https://jira.corp.adobe.com/browse/MWPW-169383)

Test URLs:

Before: https://main--bacom--adobecom.aem.live/?martech=off
After: https://mwpw-169383--bacom--robert-bogos.aem.live/?martech=off
